### PR TITLE
fix: handle both rules files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All notable changes to this project will be documented in this file.
 
 - Browser commands (`open`, `act`, `observe`, `extract`) now have `--console` and `--network` options enabled by default. Use `--no-console` and `--no-network` to disable them. 
 - Improved page reuse in browser commands when using `--connect-to`: now reuses existing tabs instead of creating new ones for better state preservation
+- Improved error handling and type safety in cursor rules management
+- Enhanced directory creation order in installation process
+
+### Added
+- Support for new Cursor IDE project rules structure
+  - New installations now use `.cursor/rules/cursor-tools.mdc`
+  - Maintain compatibility with legacy `.cursorrules` file
+  - When both exist, prefer new path and show warning
+  - Updated documentation to reflect new path structure
 
 ### Added
 - Added support for the `gpt-4o` model in browser commands (`act`, `extract`, `observe`)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here are two examples:
 
 ## What is cursor-tools
 
-`cursor-tools` provides a CLI that your **AI agent can use** to expand its capabilities. `cursor-tools` works with with Cursor (and is compatible with other agents), When you run `cursor-tools install` we automatically add a prompt section to your `.cursorrules` file so that it works out of the box with Cursor, there's not need for additional prompts.
+`cursor-tools` provides a CLI that your **AI agent can use** to expand its capabilities. `cursor-tools` works with with Cursor (and is compatible with other agents), When you run `cursor-tools install` we automatically add a prompt section to your Cursor project rules (`.cursor/rules/cursor-tools.mdc` or legacy `.cursorrules` file) so that it works out of the box with Cursor, there's no need for additional prompts.
 
 `cursor-tools` requires a Perplexity API key and a Google AI API key.
 
@@ -93,7 +93,7 @@ This command will:
 
 1. Add `cursor-tools` as a dev dependency in your package.json
 2. Guide you through API key configuration
-3. Update your `.cursorrules` file for Cursor integration
+3. Update your Cursor project rules for Cursor integration (using `.cursor/rules/cursor-tools.mdc` or existing `.cursorrules`)
 
 ## Requirements
 
@@ -555,10 +555,12 @@ If no model is specified (either on the command line or in the config), a defaul
 Available models depend on your configured provider (OpenAI or Anthropic) in `cursor-tools.config.json` and your API key.
 
 ### Cursor Configuration
-`cursor-tools` automatically configures Cursor by updating your `.cursorrules` file during installation. This provides:
+`cursor-tools` automatically configures Cursor by updating your project rules during installation. This provides:
 - Command suggestions
 - Usage examples
 - Context-aware assistance
+
+For new installations, we use the recommended `.cursor/rules/cursor-tools.mdc` path. For existing installations, we maintain compatibility with the legacy `.cursorrules` file. If both files exist, we prefer the new path and show a warning.
 
 #### Cursor Agent Configuration:
 

--- a/src/repomix/repomixConfig.ts
+++ b/src/repomix/repomixConfig.ts
@@ -16,7 +16,7 @@ export const ignorePatterns = [
   '**/*.tsbuildinfo',
 ];
 
-export const includePatterns = ['**/*', '!.cursorrules'];
+export const includePatterns = ['**/*', '!.cursorrules', '!.cursor/rules/cursor-tools.mdc'];
 
 export const outputOptions = {
   style: 'xml',


### PR DESCRIPTION
- When fresh install, use new path
- When existing install with legacy, keep using legacy and print message
- When existing install with new, keep using new and print message
- When existing install with both, keep using new and print message

chore: update docs around cursor rules file

chore: update CHANGELOG

feat: enhance rules file template

refactor: improve error handling and type safety in checkCursorRules

refactor: improve directory creation order and yield usage in install command

chore: update CHANGELOG

chore: cursor forgot unused var