### PR TITLE
Add OpenAI and OpenRouter support

### DIFF
--- a/.cursor-tools.env.example
+++ b/.cursor-tools.env.example
@@ -1,2 +1,4 @@
 PERPLEXITY_API_KEY="your-api-key-here"
 GEMINI_API_KEY="your-api-key-here"
+OPENAI_API_KEY="your-api-key-here"
+OPENROUTER_API_KEY="your-api-key-here"

--- a/.cursorrules
+++ b/.cursorrules
@@ -40,6 +40,20 @@ note: this command will exit as soon as chrome is open so you can just execute i
 # Instructions
 Use the following commands to get AI assistance:
 
+**Implementation Planning:**
+`cursor-tools plan "<query>"` - Generate a focused implementation plan using AI (e.g., `cursor-tools plan "Add user authentication to the login page"`)
+The plan command uses multiple AI models to:
+1. Identify relevant files in your codebase
+2. Extract content from those files
+3. Generate a detailed implementation plan
+
+**Plan Command Options:**
+--fileProvider=<provider>: Provider for file identification (gemini, openai, or openrouter)
+--thinkingProvider=<provider>: Provider for plan generation (gemini, openai, or openrouter)
+--fileModel=<model>: Model to use for file identification
+--thinkingModel=<model>: Model to use for plan generation
+--debug: Show detailed error information
+
 **Web Search:**
 `cursor-tools web "<your question>"` - Get answers from the web using Perplexity AI (e.g., `cursor-tools web "latest weather in London"`)
 when using web for complex queries suggest writing the output to a file somewhere like local-research/<query summary>.md.
@@ -63,8 +77,12 @@ when using doc for remote repos suggest writing the output to a file somewhere l
 
 **Notes on Browser Commands:**
 - All browser commands are stateless: each command starts with a fresh browser instance and closes it when done.
+- When using `--connect-to`, special URL values are supported:
+  - `current`: Use the existing page without reloading
+  - `reload-current`: Use the existing page and refresh it (useful in development)
 - Multi step workflows involving state or combining multiple actions are supported in the `act` command using the pipe (|) separator (e.g., `cursor-tools browser act "Click Login | Type 'user@example.com' into email | Click Submit" --url=https://example.com`)
 - Video recording is available for all browser commands using the `--video=<directory>` option. This will save a video of the entire browser interaction at 1280x720 resolution. The video file will be saved in the specified directory with a timestamp.
+- DO NOT ask browser act to "wait" for anything, the wait command is currently disabled in Stagehand.
 
 **Tool Recommendations:**
 - `cursor-tools web` is best for general web information not specific to the repository.
@@ -82,24 +100,32 @@ when using doc for remote repos suggest writing the output to a file somewhere l
 --save-to=<file path>: Save command output to a file (in *addition* to displaying it)
 --help: View all available options (help is not fully implemented yet)
 
+**Repository Command Options:**
+--provider=<provider>: AI provider to use (gemini, openai, or openrouter)
+--model=<model>: Model to use for repository analysis
+--max-tokens=<number>: Maximum tokens for response
+
 **Documentation Command Options:**
 --from-github=<GitHub username>/<repository name>[@<branch>]: Generate documentation for a remote GitHub repository
+--provider=<provider>: AI provider to use (gemini, openai, or openrouter)
+--model=<model>: Model to use for documentation generation
+--max-tokens=<number>: Maximum tokens for response
 
 **GitHub Command Options:**
 --from-github=<GitHub username>/<repository name>[@<branch>]: Access PRs/issues from a specific GitHub repository
 
 **Browser Command Options (for 'open', 'act', 'observe', 'extract'):**
---console: Capture browser console logs
+--console: Capture browser console logs (enabled by default, use --no-console to disable)
 --html: Capture page HTML content
---network: Capture network activity
+--network: Capture network activity (enabled by default, use --no-network to disable)
 --screenshot=<file path>: Save a screenshot of the page
 --timeout=<milliseconds>: Set navigation timeout (default: 30000ms)
---viewport=<width>x<height>: Set viewport size (e.g., 1280x720)
+--viewport=<width>x<height>: Set viewport size (e.g., 1280x720). When using --connect-to, viewport is only changed if this option is explicitly provided
 --headless: Run browser in headless mode (default: true)
 --no-headless: Show browser UI (non-headless mode) for debugging
 --connect-to=<port>: Connect to existing Chrome instance
 --wait=<duration or selector>: Wait after page load (e.g., '5s', '#element-id', 'selector:.my-class')
---video=<directory>: Save a video recording of the browser interaction to the specified directory (1280x720 resolution)
+--video=<directory>: Save a video recording of the browser interaction to the specified directory (1280x720 resolution). Not available when using --connect-to
 
 **Additional Notes:**
 - For detailed information, see `node_modules/cursor-tools/README.md` (if installed locally).
@@ -107,5 +133,5 @@ when using doc for remote repos suggest writing the output to a file somewhere l
 - API keys are loaded from `.cursor-tools.env` (or `~/.cursor-tools/.env`).
 - Browser commands require separate installation of Playwright: `npm install --save-dev playwright` or `npm install -g playwright`.
 - **Remember:** You're part of a team of superhuman expert AIs. Work together to solve complex problems.
-<!-- cursor-tools-version: 0.4.3-alpha.10 -->
+<!-- cursor-tools-version: 0.5.0 -->
 </cursor-tools Integration>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ All notable changes to this project will be documented in this file.
   - If no model is specified, a default model is used based on the configured provider (OpenAI or Anthropic)
 - **Internal:** Bundled Stagehand script directly into the codebase to prevent dependency issues
 - **Build:** Added stagehand script verification to the release process
+- Enhanced `plan` command with dual-provider architecture:
+  - Separate providers for file identification and plan generation
+  - `fileProvider` handles repository file analysis
+  - `thinkingProvider` generates implementation plans
+  - New command options:
+    - `--fileProvider`: Provider for file identification (gemini, openai, or openrouter)
+    - `--thinkingProvider`: Provider for plan generation (gemini, openai, or openrouter)
+    - `--fileModel`: Model to use for file identification
+    - `--thinkingModel`: Model to use for plan generation
+    - `--fileMaxTokens`: Maximum tokens for file identification
+    - `--thinkingMaxTokens`: Maximum tokens for plan generation
+- Improved provider system with enhanced error handling and configuration:
+  - New provider interfaces for specialized tasks
+  - Shared implementations via provider mixins
+  - Better error messages and debugging support
+  - Configurable system prompts for different tasks
 
 ## [0.4.3-alpha.23] - 2024-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Browser commands (`open`, `act`, `observe`, `extract`) now have `--console` and `--network` options enabled by default. Use `--no-console` and `--no-network` to disable them. 
+- Improved page reuse in browser commands when using `--connect-to`: now reuses existing tabs instead of creating new ones for better state preservation
+- Improved error handling and type safety in cursor rules management
+- Enhanced directory creation order in installation process
+
 ### Added
-- Refactored provider system for better maintainability and type safety:
-  - Removed top-level gemini provider in favor of command-specific providers
-  - Added shared base provider class with common functionality
-  - Implemented command-specific provider mixins for shared behavior
-  - Added provider-specific customization through abstract methods
-  - Improved error handling with custom error classes
-  - Added consistent provider interface across all commands
-  - Added smart token count handling for large repositories
-- Enhanced configuration system:
-  - Added strict type checking for provider configurations
-  - Capped all maxTokens values at 8192 for better consistency
-  - Added proper model defaults for each provider
-  - Added timeout configurations for all commands
-  - Enhanced browser.stagehand configuration with model and timeout settings
 - Support for new Cursor IDE project rules structure
   - New installations now use `.cursor/rules/cursor-tools.mdc`
   - Maintain compatibility with legacy `.cursorrules` file
@@ -27,58 +20,10 @@ All notable changes to this project will be documented in this file.
   - Updated documentation to reflect new path structure
 - Added support for the `gpt-4o` model in browser commands (`act`, `extract`, `observe`)
   - The model can be selected using the `--model=gpt-4o` command-line option
-  - The default model can be configured in `browser.stagehand.model`
+  - The default model can be configured in `cursor-tools.config.json`
   - If no model is specified, a default model is used based on the configured provider (OpenAI or Anthropic)
 - **Internal:** Bundled Stagehand script directly into the codebase to prevent dependency issues
 - **Build:** Added stagehand script verification to the release process
-- New `plan` command for generating focused implementation plans using AI:
-  - Uses multiple AI models to identify relevant files and generate plans
-  - Configurable file and thinking providers (gemini, openai, openrouter)
-  - Customizable models and token limits for each step
-- Added OpenRouter support for AI providers:
-  - Available for plan, repo, and doc commands
-  - Compatible with OpenAI API interface
-  - Configurable through provider options
-- Enhanced provider system with command-specific configurations:
-  - Each command can use different providers and models
-  - Configurable through command options or config file
-  - Improved type safety and error handling
-
-### Changed
-- Browser commands (`open`, `act`, `observe`, `extract`) improvements:
-  - Console and network logging now enabled by default
-    - Use `--no-console` to disable console logging
-    - Use `--no-network` to disable network logging
-  - Enhanced `--connect-to` behavior:
-    - Added special URL values: `current` and `reload-current`
-    - Viewport size only changed if `--viewport` explicitly provided
-    - Video recording not available with `--connect-to`
-  - Improved page reuse when using `--connect-to`
-  - Added warning about disabled wait command in Stagehand
-- Repository analysis command now supports multiple providers:
-  - Added `--provider` option to select AI provider
-  - Configurable default provider in config file
-  - Enhanced error handling and debugging support
-  - Provider-specific system prompts
-- Documentation generation command now supports multiple providers:
-  - Added `--provider` option to select AI provider
-  - Configurable default provider in config file
-  - Improved token count handling and model selection
-  - Better error messages and debugging information
-  - Smart model switching for large repositories
-- Updated documentation to reflect new features and changes
-- Improved error messages and debug information support
-- Improved error handling and type safety in cursor rules management
-- Enhanced directory creation order in installation process
-- Updated configuration system to support command-specific providers
-- Enhanced documentation to reflect new provider options
-- Improved command-line argument handling for provider options
-
-### Fixed
-- Fixed browser commands to respect system color scheme when using `--connect-to`
-- Fixed browser commands to not set viewport size when using `--connect-to` without explicit `--viewport` option
-- Fixed model selection and token handling across all providers
-- Improved error handling and error messages across all commands
 
 ## [0.4.3-alpha.23] - 2024-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
-- Browser commands (`open`, `act`, `observe`, `extract`) now have `--console` and `--network` options enabled by default. Use `--no-console` and `--no-network` to disable them. 
-- Improved page reuse in browser commands when using `--connect-to`: now reuses existing tabs instead of creating new ones for better state preservation
-- Improved error handling and type safety in cursor rules management
-- Enhanced directory creation order in installation process
-
 ### Added
+- Refactored provider system for better maintainability and type safety:
+  - Removed top-level gemini provider in favor of command-specific providers
+  - Added shared base provider class with common functionality
+  - Implemented command-specific provider mixins for shared behavior
+  - Added provider-specific customization through abstract methods
+  - Improved error handling with custom error classes
+  - Added consistent provider interface across all commands
+  - Added smart token count handling for large repositories
+- Enhanced configuration system:
+  - Added strict type checking for provider configurations
+  - Capped all maxTokens values at 8192 for better consistency
+  - Added proper model defaults for each provider
+  - Added timeout configurations for all commands
+  - Enhanced browser.stagehand configuration with model and timeout settings
 - Support for new Cursor IDE project rules structure
   - New installations now use `.cursor/rules/cursor-tools.mdc`
   - Maintain compatibility with legacy `.cursorrules` file
@@ -20,10 +27,58 @@ All notable changes to this project will be documented in this file.
   - Updated documentation to reflect new path structure
 - Added support for the `gpt-4o` model in browser commands (`act`, `extract`, `observe`)
   - The model can be selected using the `--model=gpt-4o` command-line option
-  - The default model can be configured in `cursor-tools.config.json`
+  - The default model can be configured in `browser.stagehand.model`
   - If no model is specified, a default model is used based on the configured provider (OpenAI or Anthropic)
 - **Internal:** Bundled Stagehand script directly into the codebase to prevent dependency issues
 - **Build:** Added stagehand script verification to the release process
+- New `plan` command for generating focused implementation plans using AI:
+  - Uses multiple AI models to identify relevant files and generate plans
+  - Configurable file and thinking providers (gemini, openai, openrouter)
+  - Customizable models and token limits for each step
+- Added OpenRouter support for AI providers:
+  - Available for plan, repo, and doc commands
+  - Compatible with OpenAI API interface
+  - Configurable through provider options
+- Enhanced provider system with command-specific configurations:
+  - Each command can use different providers and models
+  - Configurable through command options or config file
+  - Improved type safety and error handling
+
+### Changed
+- Browser commands (`open`, `act`, `observe`, `extract`) improvements:
+  - Console and network logging now enabled by default
+    - Use `--no-console` to disable console logging
+    - Use `--no-network` to disable network logging
+  - Enhanced `--connect-to` behavior:
+    - Added special URL values: `current` and `reload-current`
+    - Viewport size only changed if `--viewport` explicitly provided
+    - Video recording not available with `--connect-to`
+  - Improved page reuse when using `--connect-to`
+  - Added warning about disabled wait command in Stagehand
+- Repository analysis command now supports multiple providers:
+  - Added `--provider` option to select AI provider
+  - Configurable default provider in config file
+  - Enhanced error handling and debugging support
+  - Provider-specific system prompts
+- Documentation generation command now supports multiple providers:
+  - Added `--provider` option to select AI provider
+  - Configurable default provider in config file
+  - Improved token count handling and model selection
+  - Better error messages and debugging information
+  - Smart model switching for large repositories
+- Updated documentation to reflect new features and changes
+- Improved error messages and debug information support
+- Improved error handling and type safety in cursor rules management
+- Enhanced directory creation order in installation process
+- Updated configuration system to support command-specific providers
+- Enhanced documentation to reflect new provider options
+- Improved command-line argument handling for provider options
+
+### Fixed
+- Fixed browser commands to respect system color scheme when using `--connect-to`
+- Fixed browser commands to not set viewport size when using `--connect-to` without explicit `--viewport` option
+- Fixed model selection and token handling across all providers
+- Improved error handling and error messages across all commands
 
 ## [0.4.3-alpha.23] - 2024-03-22
 

--- a/README.md
+++ b/README.md
@@ -399,26 +399,11 @@ Customize `cursor-tools` behavior by creating a `cursor-tools.config.json` file:
 {
   "perplexity": {
     "model": "sonar-pro",
-    "maxTokens": 4000
+    "maxTokens": 8000
   },
-  "plan": {
-    "fileProvider": "gemini",
-    "thinkingProvider": "openrouter",
-    "fileModel": "gemini-2.0-pro-exp-02-05",
-    "thinkingModel": "deepseek/deepseek-r1",
-    "fileMaxTokens": 8192,
-    "thinkingMaxTokens": 8192
-  },
-  "repo": {
-    "provider": "gemini",
+  "gemini": {
     "model": "gemini-2.0-pro-exp-02-05",
-    "maxTokens": 8192
-  },
-  "doc": {
-    "maxRepoSizeMB": 100,
-    "provider": "gemini",
-    "model": "gemini-2.0-pro-exp-02-05",
-    "maxTokens": 8192
+    "maxTokens": 10000
   },
   "tokenCount": {
     "encoding": "o200k_base"
@@ -441,32 +426,11 @@ Customize `cursor-tools` behavior by creating a `cursor-tools.config.json` file:
 ```
 
 The configuration supports:
-
-**Plan Command Settings:**
-- `plan.fileProvider`: Provider for file identification ('gemini', 'openai', or 'openrouter')
-- `plan.thinkingProvider`: Provider for plan generation ('gemini', 'openai', or 'openrouter')
-- `plan.fileModel`: Model to use for file identification
-- `plan.thinkingModel`: Model to use for plan generation
-- `plan.fileMaxTokens`: Maximum tokens for file identification (max 8192)
-- `plan.thinkingMaxTokens`: Maximum tokens for plan generation (max 8192)
-
-**Repository Command Settings:**
-- `repo.provider`: Provider for repository analysis ('gemini', 'openai', or 'openrouter')
-- `repo.model`: Model to use for repository analysis
-- `repo.maxTokens`: Maximum tokens for repository analysis (max 8192)
-
-**Documentation Command Settings:**
-- `doc.maxRepoSizeMB`: Maximum repository size in MB for remote processing
-- `doc.provider`: Provider for documentation generation ('gemini', 'openai', or 'openrouter')
-- `doc.model`: Model to use for documentation generation
-- `doc.maxTokens`: Maximum tokens for documentation generation (max 8192)
-
-**Perplexity Settings:**
 - `perplexity.model`: Perplexity AI model to use
 - `perplexity.maxTokens`: Maximum tokens for Perplexity responses
+- `gemini.model`: Google Gemini model to use
+- `gemini.maxTokens`: Maximum tokens for Gemini responses
 - `tokenCount.encoding`: Tokenizer to use for counting tokens (defaults to `o200k_base` which is optimized for Gemini)
-
-**Browser Command Settings:**
 - `browser.defaultViewport`: Default viewport size for browser commands
 - `browser.timeout`: Default timeout for browser commands
 - `browser.stagehand.env`: Environment for browser commands

--- a/README.md
+++ b/README.md
@@ -399,11 +399,26 @@ Customize `cursor-tools` behavior by creating a `cursor-tools.config.json` file:
 {
   "perplexity": {
     "model": "sonar-pro",
-    "maxTokens": 8000
+    "maxTokens": 4000
   },
-  "gemini": {
+  "plan": {
+    "fileProvider": "gemini",
+    "thinkingProvider": "openrouter",
+    "fileModel": "gemini-2.0-pro-exp-02-05",
+    "thinkingModel": "deepseek/deepseek-r1",
+    "fileMaxTokens": 8192,
+    "thinkingMaxTokens": 8192
+  },
+  "repo": {
+    "provider": "gemini",
     "model": "gemini-2.0-pro-exp-02-05",
-    "maxTokens": 10000
+    "maxTokens": 8192
+  },
+  "doc": {
+    "maxRepoSizeMB": 100,
+    "provider": "gemini",
+    "model": "gemini-2.0-pro-exp-02-05",
+    "maxTokens": 8192
   },
   "tokenCount": {
     "encoding": "o200k_base"
@@ -426,11 +441,32 @@ Customize `cursor-tools` behavior by creating a `cursor-tools.config.json` file:
 ```
 
 The configuration supports:
+
+**Plan Command Settings:**
+- `plan.fileProvider`: Provider for file identification ('gemini', 'openai', or 'openrouter')
+- `plan.thinkingProvider`: Provider for plan generation ('gemini', 'openai', or 'openrouter')
+- `plan.fileModel`: Model to use for file identification
+- `plan.thinkingModel`: Model to use for plan generation
+- `plan.fileMaxTokens`: Maximum tokens for file identification (max 8192)
+- `plan.thinkingMaxTokens`: Maximum tokens for plan generation (max 8192)
+
+**Repository Command Settings:**
+- `repo.provider`: Provider for repository analysis ('gemini', 'openai', or 'openrouter')
+- `repo.model`: Model to use for repository analysis
+- `repo.maxTokens`: Maximum tokens for repository analysis (max 8192)
+
+**Documentation Command Settings:**
+- `doc.maxRepoSizeMB`: Maximum repository size in MB for remote processing
+- `doc.provider`: Provider for documentation generation ('gemini', 'openai', or 'openrouter')
+- `doc.model`: Model to use for documentation generation
+- `doc.maxTokens`: Maximum tokens for documentation generation (max 8192)
+
+**Perplexity Settings:**
 - `perplexity.model`: Perplexity AI model to use
 - `perplexity.maxTokens`: Maximum tokens for Perplexity responses
-- `gemini.model`: Google Gemini model to use
-- `gemini.maxTokens`: Maximum tokens for Gemini responses
 - `tokenCount.encoding`: Tokenizer to use for counting tokens (defaults to `o200k_base` which is optimized for Gemini)
+
+**Browser Command Settings:**
 - `browser.defaultViewport`: Default viewport size for browser commands
 - `browser.timeout`: Default timeout for browser commands
 - `browser.stagehand.env`: Environment for browser commands

--- a/README.md
+++ b/README.md
@@ -177,18 +177,36 @@ Use Perplexity AI to get up-to-date information directly within Cursor:
 cursor-tools web "What's new in TypeScript 5.7?"
 ```
 
-### Gemini 2.0: Repository Context
-Leverage Google Gemini 2.0 models with 1M+ token context windows for codebase-aware assistance:
+### Gemini 2.0: Repository Context & Planning
+Leverage Google Gemini 2.0 models with 1M+ token context windows for codebase-aware assistance and implementation planning:
+
 ```bash
+# Get context-aware assistance
 cursor-tools repo "Explain the authentication flow in this project, which files are involved?"
+
+# Generate implementation plans
+cursor-tools plan "Add user authentication to the login page"
 ```
+
+The plan command uses multiple AI models to:
+1. Identify relevant files in your codebase (using Gemini by default)
+2. Extract content from those files
+3. Generate a detailed implementation plan (using OpenRouter by default)
+
+**Plan Command Options:**
+- `--fileProvider=<provider>`: Provider for file identification (gemini, openai, or openrouter)
+- `--thinkingProvider=<provider>`: Provider for plan generation (gemini, openai, or openrouter)
+- `--fileModel=<model>`: Model to use for file identification
+- `--thinkingModel=<model>`: Model to use for plan generation
+- `--fileMaxTokens=<number>`: Maximum tokens for file identification
+- `--thinkingMaxTokens=<number>`: Maximum tokens for plan generation
+- `--debug`: Show detailed error information
 
 Repository context is created using Repomix. See repomix configuration section below for details on how to change repomix behaviour.
 
 Above 1M tokens cursor-tools will always send requests to Gemini 2.0 Pro as it is the only model that supports 1M+ tokens.
 
 The Gemini 2.0 Pro context limit is 2M tokens, you can add filters to .repomixignore if your repomix context is above this limit.
-
 
 ### Stagehand: Browser Automation
 Automate browser interactions for web scraping, testing, and debugging:

--- a/cursor-tools.config.json
+++ b/cursor-tools.config.json
@@ -1,7 +1,7 @@
 {
   "perplexity": {
     "model": "sonar-pro",
-    "maxTokens": 4000
+    "maxTokens": 8000
   },
   "plan": {
     "fileProvider": "gemini",
@@ -14,13 +14,13 @@
   "repo": {
     "provider": "gemini",
     "model": "gemini-2.0-pro-exp-02-05",
-    "maxTokens": 8192
+    "maxTokens": 10000
   },
   "doc": {
     "maxRepoSizeMB": 100,
     "provider": "gemini",
     "model": "gemini-2.0-pro-exp-02-05",
-    "maxTokens": 8192
+    "maxTokens": 10000
   },
   "tokenCount": {
     "encoding": "o200k_base"
@@ -28,14 +28,12 @@
   "browser": {
     "headless": true,
     "defaultViewport": "1280x720",
-    "timeout": 120000,
-    "stagehand": {
-      "provider": "openai",
-      "verbose": true,
-      "debugDom": false,
-      "enableCaching": true,
-      "timeout": 120000,
-      "model": "o3-mini"
-    }
+    "timeout": 120000
+  },
+  "stagehand": {
+    "provider": "openai",
+    "verbose": true,
+    "debugDom": false,
+    "enableCaching": true
   }
 }

--- a/cursor-tools.config.json
+++ b/cursor-tools.config.json
@@ -1,9 +1,26 @@
 {
   "perplexity": {
-    "model": "sonar-pro"
+    "model": "sonar-pro",
+    "maxTokens": 4000
   },
-  "gemini": {
-    "model": "gemini-2.0-pro-exp-02-05"
+  "plan": {
+    "fileProvider": "gemini",
+    "thinkingProvider": "openrouter",
+    "fileModel": "gemini-2.0-pro-exp-02-05",
+    "thinkingModel": "deepseek/deepseek-r1",
+    "fileMaxTokens": 8192,
+    "thinkingMaxTokens": 8192
+  },
+  "repo": {
+    "provider": "gemini",
+    "model": "gemini-2.0-pro-exp-02-05",
+    "maxTokens": 8192
+  },
+  "doc": {
+    "maxRepoSizeMB": 100,
+    "provider": "gemini",
+    "model": "gemini-2.0-pro-exp-02-05",
+    "maxTokens": 8192
   },
   "tokenCount": {
     "encoding": "o200k_base"
@@ -11,12 +28,14 @@
   "browser": {
     "headless": true,
     "defaultViewport": "1280x720",
-    "timeout": 120000
-  },
-  "stagehand": {
-    "provider": "openai",
-    "verbose": true,
-    "debugDom": false,
-    "enableCaching": true
+    "timeout": 120000,
+    "stagehand": {
+      "provider": "openai",
+      "verbose": true,
+      "debugDom": false,
+      "enableCaching": true,
+      "timeout": 120000,
+      "model": "o3-mini"
+    }
   }
 }

--- a/cursor-tools.config.json
+++ b/cursor-tools.config.json
@@ -1,7 +1,10 @@
 {
   "perplexity": {
-    "model": "sonar-pro",
-    "maxTokens": 8000
+    "model": "sonar-pro"
+  },
+  "gemini": {
+    "model": "gemini-2.0-pro-exp-02-05",
+    "maxTokens": 10000
   },
   "plan": {
     "fileProvider": "gemini",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@types/bun": "^1.2.2",
     "@types/node": "^22.13.1",
     "@typescript-eslint/eslint-plugin": "^8.23.0",
     "@typescript-eslint/parser": "^8.23.0",
@@ -52,7 +51,7 @@
     "prettier": "^3.4.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
-    "vitest": "^1.4.0"
+    "vitest": "^3.0.5"
   },
   "dependencies": {
     "@browserbasehq/stagehand": "1.12.0",
@@ -64,7 +63,7 @@
     "zod": "3.24.1"
   },
   "peerDependencies": {
-    "playwright": "^1.50.1"
+    "playwright": "1.50.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@types/bun": "^1.2.2",
     "@types/node": "^22.13.1",
     "@typescript-eslint/eslint-plugin": "^8.23.0",
     "@typescript-eslint/parser": "^8.23.0",
-    "bun-types": "^1.0.35",
+    "cursor-tools": "latest",
     "esbuild": "^0.24.2",
     "eslint": "^9.19.0",
     "globals": "^15.14.0",

--- a/package.json
+++ b/package.json
@@ -45,25 +45,26 @@
     "@types/node": "^22.13.1",
     "@typescript-eslint/eslint-plugin": "^8.23.0",
     "@typescript-eslint/parser": "^8.23.0",
-    "cursor-tools": "latest",
+    "bun-types": "^1.0.35",
     "esbuild": "^0.24.2",
     "eslint": "^9.19.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.5"
+    "vitest": "^1.4.0"
   },
   "dependencies": {
     "@browserbasehq/stagehand": "1.12.0",
     "dotenv": "16.4.7",
     "eventsource-client": "1.1.3",
+    "openai": "^4.83.0",
     "punycode": "^2.3.1",
     "repomix": "0.2.24",
     "zod": "3.24.1"
   },
   "peerDependencies": {
-    "playwright": "1.50.1"
+    "playwright": "^1.50.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ importers:
       eventsource-client:
         specifier: 1.1.3
         version: 1.1.3
-      playwright:
-        specifier: 1.50.1
-        version: 1.50.1
+      openai:
+        specifier: ^4.83.0
+        version: 4.83.0(ws@8.18.0)(zod@3.24.1)
       punycode:
         specifier: ^2.3.1
         version: 2.3.1
@@ -36,6 +36,9 @@ importers:
       '@types/bun':
         specifier: ^1.2.2
         version: 1.2.2
+      '@types/commander':
+        specifier: ^2.12.5
+        version: 2.12.5
       '@types/node':
         specifier: ^22.13.1
         version: 22.13.1
@@ -57,6 +60,9 @@ importers:
       globals:
         specifier: ^15.14.0
         version: 15.14.0
+      playwright:
+        specifier: ^1.50.1
+        version: 1.50.1
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -677,6 +683,10 @@ packages:
 
   '@types/bun@1.2.2':
     resolution: {integrity: sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w==}
+
+  '@types/commander@2.12.5':
+    resolution: {integrity: sha512-YXGZ/rz+s57VbzcvEV9fUoXeJlBt5HaKu5iUheiIWNsJs23bz6AnRuRiZBRVBLYyPnixNvVnuzM5pSaxr8Yp/g==}
+    deprecated: This is a stub types definition. commander provides its own type definitions, so you do not need this installed.
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -2139,6 +2149,10 @@ snapshots:
   '@types/bun@1.2.2':
     dependencies:
       bun-types: 1.2.2
+
+  '@types/commander@2.12.5':
+    dependencies:
+      commander: 13.1.0
 
   '@types/estree@1.0.6': {}
 

--- a/src/commands/browser/element.ts
+++ b/src/commands/browser/element.ts
@@ -1,5 +1,6 @@
 import type { Command, CommandGenerator, CommandOptions } from '../../types';
 import { chromium } from 'playwright';
+import type { Browser } from 'playwright';
 import { loadConfig } from '../../config.ts';
 import { ensurePlaywright } from './utils.ts';
 
@@ -14,8 +15,9 @@ interface ElementBrowserOptions extends CommandOptions {
 export class ElementCommand implements Command {
   private config = loadConfig();
 
-  async *execute(query: string, options?: ElementBrowserOptions): CommandGenerator {
-    let browser;
+  async *execute(query: string, initialOptions?: ElementBrowserOptions): CommandGenerator {
+    let browser: Browser | undefined;
+    let options = { ...initialOptions };
     try {
       // Check for Playwright availability first
       await ensurePlaywright();

--- a/src/commands/browser/stagehand/act.ts
+++ b/src/commands/browser/stagehand/act.ts
@@ -1,12 +1,7 @@
 import type { Command, CommandGenerator } from '../../../types';
 import { formatOutput, handleBrowserError, ActionError, NavigationError } from './stagehandUtils';
-import {
-  BrowserResult,
-  ConstructorParams,
-  InitResult,
-  LogLine,
-  Stagehand,
-} from '@browserbasehq/stagehand';
+import type { ConstructorParams } from '@browserbasehq/stagehand';
+import { Stagehand } from '@browserbasehq/stagehand';
 import { loadConfig } from '../../../config';
 import {
   loadStagehandConfig,
@@ -34,7 +29,8 @@ export type RecordVideoOptions = {
 overrideStagehandInit();
 
 export class ActCommand implements Command {
-  async *execute(query: string, options?: SharedBrowserCommandOptions): CommandGenerator {
+  async *execute(query: string, initialOptions?: SharedBrowserCommandOptions): CommandGenerator {
+    let options = { ...initialOptions };
     if (!query) {
       yield 'Please provide an instruction and URL. Usage: browser act "<instruction>" --url <url>';
       return;
@@ -166,7 +162,7 @@ export class ActCommand implements Command {
       }
     } catch (error) {
       console.log('error in stagehand loop');
-      yield 'error in stagehand: ' + handleBrowserError(error, options?.debug);
+      yield `error in stagehand: ${handleBrowserError(error, options?.debug)}`;
     }
   }
 
@@ -187,6 +183,7 @@ export class ActCommand implements Command {
       let totalTimeout: ReturnType<typeof setTimeout> | undefined;
       const totalTimeoutPromise = new Promise(
         (_, reject) =>
+          // biome-ignore lint/suspicious/noAssignInExpressions: guessing it should be 
           (totalTimeout = setTimeout(() => reject(new Error('Action timeout')), timeout))
       );
 

--- a/src/commands/browser/utilsShared.ts
+++ b/src/commands/browser/utilsShared.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright';
+import type { ConsoleMessage, Page } from 'playwright';
 import type { SharedBrowserCommandOptions } from './browserOptions';
 import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -18,7 +18,7 @@ import type { CommandGenerator } from '../../types';
  * });
  * ```
  */
-export async function formatConsoleMessage(msg: any): Promise<string> {
+export async function formatConsoleMessage(msg: ConsoleMessage): Promise<string> {
   const type = msg.type();
   const text = msg.text();
   const location = msg.location();
@@ -38,6 +38,7 @@ export async function formatConsoleMessage(msg: any): Promise<string> {
   // For errors, try to get the stack trace
   if (type === 'error') {
     try {
+      // biome-ignore lint/suspicious/noExplicitAny: 
       const args = await Promise.all(msg.args().map((arg: any) => arg.jsonValue()));
       const errorDetails = args.find(
         (arg: unknown) => arg && typeof arg === 'object' && 'stack' in arg
@@ -192,7 +193,7 @@ export function outputMessages(
   if (options.network === true && networkMessages.length > 0) {
     output.push('\n--- Network Activity ---\n');
     for (const msg of networkMessages) {
-      output.push(msg + '\n');
+      output.push(`${msg}\n`);
     }
     output.push('--- End of Network Activity ---\n');
   }
@@ -201,7 +202,7 @@ export function outputMessages(
   if (options.console === true && consoleMessages.length > 0) {
     output.push('\n--- Console Messages ---\n');
     for (const msg of consoleMessages) {
-      output.push(msg + '\n');
+      output.push(`${msg}\n`);
     }
     output.push('--- End of Console Messages ---\n');
   }

--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -1,12 +1,21 @@
-import type { Command, CommandGenerator, CommandOptions } from '../types.ts';
-import type { Config } from '../config.ts';
-import { loadConfig, loadEnv } from '../config.ts';
-import { readFileSync, writeFileSync } from 'node:fs';
+import type { Command, CommandGenerator } from '../types';
+import type { Config } from '../config';
+import { loadConfig, loadEnv } from '../config';
 import { pack } from 'repomix';
-import { ignorePatterns, includePatterns, outputOptions } from '../repomix/repomixConfig.ts';
-interface DocCommandOptions extends CommandOptions {
-  output?: string; // Optional output file path
-  fromGithub?: string; // GitHub URL or username/reponame
+import { readFileSync, writeFileSync } from 'node:fs';
+import { DocError, DocGenerationError, FileError, NetworkError } from '../errors';
+import type { ModelOptions, BaseModelProvider } from '../providers/base';
+import { GeminiProvider, OpenAIProvider, OpenRouterProvider } from '../providers/base';
+import { ModelNotFoundError } from '../errors';
+
+interface DocCommandOptions {
+  model?: string;
+  maxTokens?: number;
+  output?: string;
+  fromGithub?: string;
+  hint?: string;
+  debug?: boolean;
+  provider?: 'gemini' | 'openai' | 'openrouter';
 }
 
 export class DocCommand implements Command {
@@ -30,7 +39,7 @@ export class DocCommand implements Command {
     const [repoPath, branch] = url.split('@');
     const parts = repoPath.split('/');
     if (parts.length !== 2) {
-      throw new Error(
+      throw new DocError(
         'Invalid GitHub repository format. Use either https://github.com/username/reponame[@branch] or username/reponame[@branch]'
       );
     }
@@ -38,10 +47,8 @@ export class DocCommand implements Command {
     return { username: parts[0], reponame: parts[1], branch };
   }
 
-  private async getGithubRepoContext(
-    githubUrl: string
-  ): Promise<{ text: string; tokenCount: number }> {
-    const { username, reponame, branch } = this.parseGithubUrl(githubUrl);
+  private async getGithubRepoContext(repoPath: string): Promise<{ text: string; tokenCount: number }> {
+    const { username, reponame, branch } = this.parseGithubUrl(repoPath);
     const repoIdentifier = `${username}/${reponame}`;
 
     // First check repository size using GitHub API
@@ -56,12 +63,12 @@ export class DocCommand implements Command {
 
       // If repo is larger than the limit, throw an error
       if (sizeInMB > maxSize) {
-        throw new Error(
-          `Repository ${repoIdentifier} is too large (${Math.round(sizeInMB)}MB) to process remotely.\n` +
-            `The current size limit is ${maxSize}MB. You can:\n` +
-            `1. Increase the limit by setting doc.maxRepoSizeMB in cursor-tools.config.json\n` +
-            `2. Clone the repository locally and run cursor-tools doc without --fromGithub\n` +
-            `3. The local processing will be more efficient and can handle larger codebases`
+        throw new DocError(
+          `Repository ${repoIdentifier} is too large (${Math.round(sizeInMB)}MB) to process remotely.
+The current size limit is ${maxSize}MB. You can:
+1. Increase the limit by setting doc.maxRepoSizeMB in cursor-tools.config.json
+2. Clone the repository locally and run cursor-tools doc without --fromGithub
+3. The local processing will be more efficient and can handle larger codebases`
         );
       }
     } else {
@@ -95,8 +102,8 @@ export class DocCommand implements Command {
               fileSummary: true,
               directoryStructure: true,
               outputParsable: false,
-              includePatterns: includePatterns.join(','),
-              ignorePatterns: ignorePatterns.join(','),
+              includePatterns: ['**/*'],
+              ignorePatterns: ['.git/**', 'node_modules/**'],
             },
             signal: {},
           }),
@@ -129,18 +136,18 @@ export class DocCommand implements Command {
           errorText.toLowerCase().includes('timeout') ||
           errorText.toLowerCase().includes('too large')
         ) {
-          throw new Error(
-            `Repository ${repoIdentifier} appears to be too large to process remotely.\n` +
-              `Please:\n` +
-              `1. Clone the repository locally\n` +
-              `2. Run cursor-tools doc without --fromGithub\n` +
-              `3. The local processing will be more efficient and can handle larger codebases`
+          throw new DocError(
+            `Repository ${repoIdentifier} appears to be too large to process remotely.
+Please:
+1. Clone the repository locally
+2. Run cursor-tools doc without --fromGithub
+3. The local processing will be more efficient and can handle larger codebases`
           );
         }
 
         // If this is the last attempt, throw the error
         if (attempt === MAX_RETRIES) {
-          throw new Error(
+          throw new NetworkError(
             `Failed to fetch GitHub repository context: ${response.statusText}\n${errorText}`
           );
         }
@@ -148,13 +155,13 @@ export class DocCommand implements Command {
         // For 5xx errors (server errors) and 429 (rate limit), retry
         // For other errors (like 4xx client errors), throw immediately
         if (!(response.status >= 500 || response.status === 429)) {
-          throw new Error(
+          throw new NetworkError(
             `Failed to fetch GitHub repository context: ${response.statusText}\n${errorText}`
           );
         }
 
         // Calculate delay with exponential backoff and jitter
-        const delay = INITIAL_DELAY * Math.pow(2, attempt - 1) * (0.5 + Math.random());
+        const delay = INITIAL_DELAY * (2 ** (attempt - 1)) * (0.5 + Math.random());
         console.error(
           `Attempt ${attempt} failed. Retrying in ${Math.round(delay / 1000)} seconds...`
         );
@@ -167,7 +174,7 @@ export class DocCommand implements Command {
 
         // For network errors (like timeouts), retry
         if (error instanceof Error) {
-          const delay = INITIAL_DELAY * Math.pow(2, attempt - 1) * (0.5 + Math.random());
+          const delay = INITIAL_DELAY * (2 ** (attempt - 1)) * (0.5 + Math.random());
           console.error(`Attempt ${attempt} failed: ${error.message}`);
           console.error(`Retrying in ${Math.round(delay / 1000)} seconds...`);
           await new Promise((resolve) => setTimeout(resolve, delay));
@@ -176,94 +183,7 @@ export class DocCommand implements Command {
     }
 
     // This should never be reached due to the throw in the last iteration
-    throw new Error('Failed to fetch GitHub repository context after all retries');
-  }
-
-  private async fetchGeminiDocResponse(
-    repoContext: { text: string; tokenCount: number },
-    options?: DocCommandOptions
-  ): Promise<string> {
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      throw new Error('GEMINI_API_KEY environment variable is not set');
-    }
-
-    // Use actual token count from repomix
-    const tokenCount = repoContext.tokenCount;
-    let model = options?.model || this.config.gemini.model;
-
-    if (tokenCount > 800_000 && tokenCount < 2_000_0000) {
-      console.error(
-        `Repository content is large (${Math.round(tokenCount / 1000)}K tokens), switching to gemini-2.0-pro-exp-02-05 model...`
-      );
-      model = 'gemini-2.0-pro-exp-02-05';
-    } else if (tokenCount >= 2_000_0000) {
-      throw new Error(
-        `Repository content is too large (${Math.round(tokenCount / 1000)}K tokens) for Gemini API.\n` +
-          `Please try:\n` +
-          `1. Using a more specific query to document a particular feature or module\n` +
-          `2. Running the documentation command on a specific directory or file\n` +
-          `3. Cloning the repository locally and using .gitignore to exclude non-essential files`
-      );
-    }
-
-    // Define a prompt for Gemini to generate documentation
-    let query = `
-Focus on:
-1. Repository purpose and "what is it" summary
-2. Quick start: How to install and use the basic core features of the project
-4. Configuration options and how to configure the project for use (if applicable)
-3. If a repository has multiple public packages perform all the following steps for every package:
-4. package summary & how to install / import it 
-5. Detailed documentation of every public feature / API / interface
-6. Dependencies and requirements
-7. Advanced usage examples`;
-
-    // Add hint if provided
-    if (options?.hint) {
-      query += `\n\nAdditional guidance:\n${options.hint}`;
-    }
-
-    console.error('Using Gemini model:', model);
-    const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          systemInstruction: {
-            parts: [
-              {
-                text: 'You are a helpful assistant that generates public user-facing documentation for a given repository. You will be given a repository context and possibly a query to create docs for a specific part or function, if this is not provided generate docs for all public interfaces and features. Generate a comprehensive documentation with all necessary information BUT stick to short simple sentences and avoid being wordy, verbose or making a sales-pitch, stick to factual statements and be concise. Format the documentation in markdown unless otherwise specified.',
-              },
-            ],
-          },
-          contents: [
-            {
-              role: 'user',
-              parts: [{ text: repoContext.text }, { text: query }],
-            },
-          ],
-          generationConfig: {
-            maxOutputTokens: options?.maxTokens || this.config.gemini.maxTokens,
-          },
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Gemini API error (${response.status}): ${errorText}`);
-    }
-
-    const data = await response.json();
-    if (data.error) {
-      throw new Error(`Gemini API error: ${JSON.stringify(data.error, null, 2)}`);
-    }
-
-    return data.candidates[0].content.parts[0].text;
+    throw new NetworkError('Failed to fetch GitHub repository context after all retries');
   }
 
   async *execute(query: string, options?: DocCommandOptions): CommandGenerator {
@@ -278,36 +198,73 @@ Focus on:
       } else {
         console.error('Packing local repository using repomix...\n');
         const tempFile = '.repomix-output.txt';
-        await pack(process.cwd(), {
-          output: {
-            ...outputOptions,
-            filePath: tempFile,
-          },
-          include: ['**/*'],
-          ignore: {
-            useGitignore: true,
-            useDefaultPatterns: true,
-            customPatterns: ignorePatterns,
-          },
-          security: {
-            enableSecurityCheck: true,
-          },
-          tokenCount: {
-            encoding: this.config.tokenCount?.encoding || 'o200k_base',
-          },
-          cwd: process.cwd(),
-        });
+        try {
+          await pack(process.cwd(), {
+            output: {
+              filePath: tempFile,
+              style: 'plain',
+              parsableStyle: false,
+              fileSummary: false,
+              directoryStructure: true,
+              removeComments: false,
+              removeEmptyLines: true,
+              showLineNumbers: false,
+              copyToClipboard: false,
+              includeEmptyDirectories: false,
+              topFilesLength: 1000
+            },
+            include: ['**/*'],
+            ignore: {
+              useGitignore: true,
+              useDefaultPatterns: true,
+              customPatterns: []
+            },
+            security: {
+              enableSecurityCheck: true
+            },
+            tokenCount: {
+              encoding: this.config.tokenCount?.encoding || 'o200k_base'
+            },
+            cwd: process.cwd()
+          });
+        } catch (error) {
+          throw new FileError('Failed to pack repository', error);
+        }
 
-        repoContext = { text: readFileSync(tempFile, 'utf-8'), tokenCount: 0 };
+        try {
+          repoContext = { text: readFileSync(tempFile, 'utf-8'), tokenCount: 0 };
+        } catch (error) {
+          throw new FileError('Failed to read repository context', error);
+        }
       }
 
-      console.error('Generating documentation using Gemini AI...\n');
-      const documentation = await this.fetchGeminiDocResponse(repoContext, options);
+      const provider = createDocProvider(options?.provider || this.config.doc?.provider || 'gemini');
+      const providerName = options?.provider || this.config.doc?.provider || 'gemini';
+      const model = options?.model || this.config?.doc?.model;
+
+      if (!model) {
+        throw new DocError(`No model specified for ${providerName}`);
+      }
+
+      console.error(`Generating documentation using ${model}...\n`);
+      let documentation: string;
+      try {
+        documentation = await provider.generateDocumentation(repoContext, {
+          model,
+          maxTokens: options?.maxTokens || this.config.doc?.maxTokens
+        });
+      } catch (error) {
+        throw new DocGenerationError(error instanceof Error ? error.message : 'Unknown error during generation', error);
+      }
 
       // Save to file if output option is provided
       if (options?.output) {
-        writeFileSync(options.output, documentation);
-        console.error(`Documentation saved to ${options.output}\n`);
+        try {
+          writeFileSync(options.output, documentation);
+          console.error(`Documentation saved to ${options.output}\n`);
+        } catch (error) {
+          throw new FileError(`Failed to save documentation to ${options.output}`, error);
+        }
       } else {
         yield '\n--- Repository Documentation ---\n\n';
         yield documentation;
@@ -316,11 +273,70 @@ Focus on:
 
       console.error('Documentation generation completed!\n');
     } catch (error) {
-      if (error instanceof Error) {
-        console.error(`Error: ${error.message}`);
+      if (error instanceof DocError || error instanceof FileError || error instanceof NetworkError) {
+        yield error.formatUserMessage(options?.debug);
+      } else if (error instanceof Error) {
+        yield `Error: ${error.message}\n`;
       } else {
-        console.error('An unknown error occurred');
+        yield 'An unknown error occurred\n';
       }
     }
   }
 }
+
+// Documentation-specific provider interface
+export interface DocModelProvider extends BaseModelProvider {
+  generateDocumentation(repoContext: { text: string; tokenCount: number }, options?: ModelOptions): Promise<string>;
+}
+
+// Shared mixin for doc providers
+const DocProviderMixin = {
+  async generateDocumentation(this: BaseModelProvider, repoContext: { text: string; tokenCount: number }, options?: ModelOptions): Promise<string> {
+    const prompt = `
+Focus on:
+1. Repository purpose and "what is it" summary
+2. Quick start: How to install and use the basic core features of the project
+3. Configuration options and how to configure the project for use (if applicable)
+4. If a repository has multiple public packages perform all the following steps for every package:
+5. Package summary & how to install / import it 
+6. Detailed documentation of every public feature / API / interface
+7. Dependencies and requirements
+8. Advanced usage examples
+
+Repository Context:
+${repoContext.text}`;
+
+    return this.executePrompt(prompt, {
+      ...options,
+      tokenCount: repoContext.tokenCount,
+      systemPrompt: 'You are a documentation expert. Generate comprehensive documentation that is clear, well-structured, and follows best practices.'
+    });
+  }
+};
+
+// Documentation provider implementations
+export class DocGeminiProvider extends GeminiProvider implements DocModelProvider {
+  generateDocumentation = DocProviderMixin.generateDocumentation;
+}
+
+export class DocOpenAIProvider extends OpenAIProvider implements DocModelProvider {
+  generateDocumentation = DocProviderMixin.generateDocumentation;
+}
+
+export class DocOpenRouterProvider extends OpenRouterProvider implements DocModelProvider {
+  generateDocumentation = DocProviderMixin.generateDocumentation;
+}
+
+// Factory function to create providers
+export function createDocProvider(provider: 'gemini' | 'openai' | 'openrouter'): DocModelProvider {
+  switch (provider) {
+    case 'gemini':
+      return new DocGeminiProvider();
+    case 'openai':
+      return new DocOpenAIProvider();
+    case 'openrouter':
+      return new DocOpenRouterProvider();
+    default:
+      throw new ModelNotFoundError(provider);
+  }
+} 

--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -1,4 +1,4 @@
-import type { Command, CommandGenerator } from '../types';
+import type { Command, CommandGenerator, CommandOptions } from '../types';
 import type { Config } from '../config';
 import { loadConfig, loadEnv } from '../config';
 import { pack } from 'repomix';
@@ -8,7 +8,7 @@ import type { ModelOptions, BaseModelProvider } from '../providers/base';
 import { GeminiProvider, OpenAIProvider, OpenRouterProvider } from '../providers/base';
 import { ModelNotFoundError } from '../errors';
 
-interface DocCommandOptions {
+interface DocCommandOptions extends CommandOptions {
   model?: string;
   maxTokens?: number;
   output?: string;

--- a/src/commands/github/utils.ts
+++ b/src/commands/github/utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 import type { CommandOptions } from '../../types';
 
 export interface GithubOptions extends CommandOptions {
@@ -15,10 +15,9 @@ function parseRepoString(repoStr: string): RepoContext | null {
   const parts = repoStr.split('/');
   if (parts.length === 2) {
     return { owner: parts[0], repo: parts[1] };
-  } else {
-    console.error("Invalid repository format. Use 'owner/repo'");
-    return null;
   }
+  console.error("Invalid repository format. Use 'owner/repo'");
+  return null;
 }
 
 export async function getRepoContext(options?: GithubOptions): Promise<RepoContext | null> {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,10 +1,11 @@
 import type { CommandMap } from '../types.ts';
 import { WebCommand } from './web.ts';
-import { RepoCommand } from './repo.ts';
+import { RepoCommand } from './repo/index.ts';
 import { InstallCommand } from './install.ts';
-import { DocCommand } from './doc.ts';
+import { DocCommand } from './doc/index.ts';
 import { GithubCommand } from './github.ts';
 import { BrowserCommand } from './browser/browserCommand.ts';
+import { PlanCommand } from './plan/index.ts';
 
 export const commands: CommandMap = {
   web: new WebCommand(),
@@ -13,4 +14,5 @@ export const commands: CommandMap = {
   doc: new DocCommand(),
   github: new GithubCommand(),
   browser: new BrowserCommand(),
+  plan: new PlanCommand(),
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,11 +1,11 @@
 import type { CommandMap } from '../types.ts';
 import { WebCommand } from './web.ts';
-import { RepoCommand } from './repo/index.ts';
 import { InstallCommand } from './install.ts';
-import { DocCommand } from './doc/index.ts';
 import { GithubCommand } from './github.ts';
 import { BrowserCommand } from './browser/browserCommand.ts';
-import { PlanCommand } from './plan/index.ts';
+import { PlanCommand } from './plan.ts';
+import { RepoCommand } from './repo.ts';
+import { DocCommand } from './doc.ts';
 
 export const commands: CommandMap = {
   web: new WebCommand(),

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,9 +1,9 @@
-import type { Command, CommandGenerator, CommandOptions } from '../types.ts';
+import type { Command, CommandGenerator, CommandOptions } from '../types';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { loadEnv } from '../config.ts';
-import { CURSOR_RULES_TEMPLATE, CURSOR_RULES_VERSION, checkCursorRules } from '../cursorrules.ts';
+import { loadEnv } from '../config';
+import { CURSOR_RULES_TEMPLATE, CURSOR_RULES_VERSION, checkCursorRules } from '../cursorrules';
 
 interface InstallOptions extends CommandOptions {
   packageManager?: 'npm' | 'yarn' | 'pnpm';

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -46,11 +46,10 @@ export class InstallCommand implements Command {
 
     // Function to write keys to a file
     const writeKeysToFile = (filePath: string, keys: Record<string, string>) => {
-      const envContent =
-        Object.entries(keys)
+      const envContent = `${Object.entries(keys)
           .filter(([_, value]) => value) // Only include keys with values
           .map(([key, value]) => `${key}=${value}`)
-          .join('\n') + '\n';
+          .join('\n')}\n`;
 
       const dir = join(filePath, '..');
       if (!existsSync(dir)) {
@@ -150,6 +149,7 @@ export class InstallCommand implements Command {
             packageJson.devDependencies['cursor-tools'] = 'latest';
             // Remove from dependencies if it exists there
             if (packageJson.dependencies?.['cursor-tools']) {
+              // biome-ignore lint/performance/noDelete: we need to delete the dependency
               delete packageJson.dependencies['cursor-tools'];
             }
             writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -7,6 +7,7 @@ import { CURSOR_RULES_TEMPLATE, CURSOR_RULES_VERSION, checkCursorRules } from '.
 
 interface InstallOptions extends CommandOptions {
   packageManager?: 'npm' | 'yarn' | 'pnpm';
+  global?: boolean;
 }
 
 // Helper function to get user input and properly close stdin

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -1,0 +1,308 @@
+import type { Command, CommandGenerator, CommandOptions } from '../types';
+import type { Config } from '../config';
+import { loadConfig, loadEnv } from '../config';
+import { pack } from 'repomix';
+import { readFileSync } from 'node:fs';
+import type { ModelOptions, BaseModelProvider } from '../providers/base';
+import { GeminiProvider, OpenAIProvider, OpenRouterProvider } from '../providers/base';
+import { ModelNotFoundError } from '../errors';
+
+// Custom error classes for better error handling
+class PlanError extends Error {
+  constructor(message: string, public readonly details?: unknown) {
+    super(message);
+    this.name = 'PlanError';
+  }
+}
+
+class FileFilterError extends PlanError {
+  constructor(message: string, details?: unknown) {
+    super(`Error during file filtering: ${message}`, details);
+    this.name = 'FileFilterError';
+  }
+}
+
+class ContentExtractionError extends PlanError {
+  constructor(message: string, details?: unknown) {
+    super(`Error during content extraction: ${message}`, details);
+    this.name = 'ContentExtractionError';
+  }
+}
+
+class PlanGenerationError extends PlanError {
+  constructor(message: string, details?: unknown) {
+    super(`Error during plan generation: ${message}`, details);
+    this.name = 'PlanGenerationError';
+  }
+}
+
+// Define plan command specific options
+interface PlanCommandOptions {
+  fileModel?: string;
+  thinkingModel?: string;
+  fileProvider?: 'gemini' | 'openai' | 'openrouter';
+  thinkingProvider?: 'gemini' | 'openai' | 'openrouter';
+  maxTokens?: number;
+  debug?: boolean;
+}
+
+export class PlanCommand implements Command {
+  private config: Config;
+
+  constructor() {
+    loadEnv();
+    this.config = loadConfig();
+  }
+
+  async *execute(query: string, options?: CommandOptions): CommandGenerator {
+    try {
+      const fileProvider = createProvider(options?.fileProvider || this.config.plan?.fileProvider || 'gemini');
+      const thinkingProvider = createProvider(options?.thinkingProvider || this.config.plan?.thinkingProvider || 'openai');
+
+      if (options?.debug) {
+        yield `Using file provider: ${options?.fileProvider || this.config.plan?.fileProvider || 'gemini'}\n`;
+        yield `Using thinking provider: ${options?.thinkingProvider || this.config.plan?.thinkingProvider || 'openai'}\n`;
+        yield `Using file model: ${options?.fileModel || this.config.plan?.fileModel}\n`;
+        yield `Using thinking model: ${options?.thinkingModel || this.config.plan?.thinkingModel}\n`;
+      }
+
+      yield 'Finding relevant files...\n';
+      
+      // Get file listing
+      let fileListing: string;
+      try {
+        if (options?.debug) {
+          yield 'Running repomix to get file listing...\n';
+        }
+
+        const tempFile = '.repomix-plan-files.txt';
+        await pack(process.cwd(), {
+          output: {
+            filePath: tempFile,
+            style: 'plain',
+            parsableStyle: true,
+            fileSummary: false,
+            directoryStructure: false,
+            removeComments: false,
+            removeEmptyLines: true,
+            showLineNumbers: false,
+            copyToClipboard: false,
+            includeEmptyDirectories: false,
+            topFilesLength: 1000
+          },
+          include: ['**/*'],
+          ignore: {
+            useGitignore: true,
+            useDefaultPatterns: true,
+            customPatterns: []
+          },
+          security: {
+            enableSecurityCheck: true
+          },
+          tokenCount: {
+            encoding: this.config.tokenCount?.encoding || 'o200k_base'
+          },
+          cwd: process.cwd()
+        });
+
+        if (options?.debug) {
+          yield 'Repomix completed successfully.\n';
+        }
+
+        fileListing = readFileSync(tempFile, 'utf-8');
+        
+        if (options?.debug) {
+          yield `Found ${fileListing.split('\n').length} files in total.\n`;
+          yield 'First few files:\n';
+          yield `${fileListing.split('\n').slice(0, 5).join('\n')}\n\n`;
+        }
+      } catch (error) {
+        throw new FileFilterError(error instanceof Error ? error.message : 'Unknown error getting file listing', error);
+      }
+
+      // Get relevant files
+      let filePaths: string[];
+      try {
+        if (options?.debug) {
+          yield 'Asking AI to identify relevant files...\n';
+        }
+
+        filePaths = await fileProvider.getRelevantFiles(query, fileListing, {
+          model: options?.fileModel || this.config.plan?.fileModel,
+          maxTokens: options?.maxTokens || this.config.plan?.fileMaxTokens
+        });
+
+        if (options?.debug) {
+          yield `AI identified ${filePaths.length} relevant files.\n`;
+          if (filePaths.length > 0) {
+            yield 'First few identified files:\n';
+            yield `${filePaths.slice(0, 5).join('\n')}\n\n`;
+          }
+        }
+      } catch (error) {
+        throw new FileFilterError(error instanceof Error ? error.message : 'Unknown error during file filtering', error);
+      }
+
+      if (filePaths.length === 0) {
+        yield 'No relevant files found. Please refine your query.\n';
+        return;
+      }
+
+      yield `Found ${filePaths.length} relevant files:\n${filePaths.join('\n')}\n\n`;
+
+      yield 'Extracting content from relevant files...\n';
+      let filteredContent: string;
+      try {
+        const tempFile = '.repomix-plan-filtered.txt';
+        await pack(process.cwd(), {
+          output: {
+            filePath: tempFile,
+            style: 'plain',
+            parsableStyle: false,
+            fileSummary: true,
+            directoryStructure: false,
+            removeComments: false,
+            removeEmptyLines: true,
+            showLineNumbers: false,
+            copyToClipboard: false,
+            includeEmptyDirectories: false,
+            topFilesLength: 1000
+          },
+          include: filePaths,
+          ignore: {
+            useGitignore: true,
+            useDefaultPatterns: true,
+            customPatterns: []
+          },
+          security: {
+            enableSecurityCheck: true
+          },
+          tokenCount: {
+            encoding: 'cl100k_base'
+          },
+          cwd: process.cwd()
+        });
+
+        if (options?.debug) {
+          yield 'Content extraction completed.\n';
+        }
+
+        filteredContent = readFileSync(tempFile, 'utf-8');
+      } catch (error) {
+        throw new ContentExtractionError(error instanceof Error ? error.message : 'Unknown error during content extraction', error);
+      }
+
+      yield 'Generating implementation plan...\n';
+      let plan: string;
+      try {
+        plan = await thinkingProvider.generatePlan(query, filteredContent, {
+          model: options?.thinkingModel || this.config.plan?.thinkingModel,
+          maxTokens: options?.maxTokens || this.config.plan?.thinkingMaxTokens
+        });
+      } catch (error) {
+        throw new PlanGenerationError(error instanceof Error ? error.message : 'Unknown error during plan generation', error);
+      }
+
+      yield plan;
+
+    } catch (error) {
+      if (error instanceof PlanError) {
+        yield `${error.name}: ${error.message}\n`;
+        if (error.details && options?.debug) {
+          yield `Debug details: ${JSON.stringify(error.details, null, 2)}\n`;
+        }
+      } else if (error instanceof Error) {
+        yield `Error: ${error.message}\n`;
+      } else {
+        yield 'An unknown error occurred\n';
+      }
+    }
+  }
+}
+
+// Plan-specific provider interface
+export interface PlanModelProvider extends BaseModelProvider {
+  getRelevantFiles(query: string, fileListing: string, options?: ModelOptions): Promise<string[]>;
+  generatePlan(query: string, repoContext: string, options?: ModelOptions): Promise<string>;
+}
+
+// Shared functionality for plan providers
+function parseFileList(fileListText: string): string[] {
+  // First try to parse as a comma-separated list
+  const files = fileListText
+    .split(/[,\n]/) // Split on commas or newlines
+    .map(f => f.trim())
+    .map(f => f.replace(/[`'"]/g, '')) // Remove quotes and backticks
+    .filter(f => f.length > 0 && !f.includes('*')); // Filter empty lines and wildcards
+
+  if (files.length > 0) {
+    return files;
+  }
+
+  // If no files found, try to extract paths using a regex
+  const pathRegex = /(?:^|\s|["'`])([a-zA-Z0-9_\-/.]+\.[a-zA-Z0-9]+)(?:["'`]|\s|$)/g;
+  const matches = Array.from(fileListText.matchAll(pathRegex), m => m[1]);
+  return matches.filter(f => f.length > 0);
+}
+
+// Shared mixin for plan providers
+const PlanProviderMixin = {
+  async getRelevantFiles(this: BaseModelProvider, query: string, fileListing: string, options?: ModelOptions): Promise<string[]> {
+    const response = await this.executePrompt(
+      `You are an expert software developer. Your task is to identify files that are relevant to the following query:
+
+Query: ${query}
+
+Below is a list of files in the repository. Return ONLY a comma-separated list of file paths that are relevant to the query.
+Do not include any other text, explanations, or markdown formatting. Just the file paths separated by commas.
+
+Files:
+${fileListing}`,
+      {
+        ...options,
+        systemPrompt: 'You are an expert software developer. You must return ONLY a comma-separated list of file paths. No other text or formatting.'
+      }
+    );
+    return parseFileList(response);
+  },
+
+  async generatePlan(this: BaseModelProvider, query: string, repoContext: string, options?: ModelOptions): Promise<string> {
+    return this.executePrompt(
+      `Query: ${query}\n\nRepository Context:\n${repoContext}`,
+      {
+        ...options,
+        systemPrompt: 'You are a helpful assistant that generates step-by-step implementation plans for software development tasks. Given a query and a repository context, generate a detailed plan. Include specific file paths, code snippets, and any necessary commands.'
+      }
+    );
+  }
+};
+
+// Plan provider implementations
+export class PlanGeminiProvider extends GeminiProvider implements PlanModelProvider {
+  getRelevantFiles = PlanProviderMixin.getRelevantFiles;
+  generatePlan = PlanProviderMixin.generatePlan;
+}
+
+export class PlanOpenAIProvider extends OpenAIProvider implements PlanModelProvider {
+  getRelevantFiles = PlanProviderMixin.getRelevantFiles;
+  generatePlan = PlanProviderMixin.generatePlan;
+}
+
+export class PlanOpenRouterProvider extends OpenRouterProvider implements PlanModelProvider {
+  getRelevantFiles = PlanProviderMixin.getRelevantFiles;
+  generatePlan = PlanProviderMixin.generatePlan;
+}
+
+// Factory function to create providers
+export function createProvider(provider: 'gemini' | 'openai' | 'openrouter'): PlanModelProvider {
+  switch (provider) {
+    case 'gemini':
+      return new PlanGeminiProvider();
+    case 'openai':
+      return new PlanOpenAIProvider();
+    case 'openrouter':
+      return new PlanOpenRouterProvider();
+    default:
+      throw new ModelNotFoundError(provider);
+  }
+} 

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -14,7 +14,7 @@ export interface PlanModelProvider extends BaseModelProvider {
 }
 
 // Define plan command specific options
-interface PlanCommandOptions {
+interface PlanCommandOptions extends CommandOptions {
   fileModel?: string;
   thinkingModel?: string;
   fileProvider?: 'gemini' | 'openai' | 'openrouter';

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -3,7 +3,7 @@ import type { Config } from '../config';
 import { loadConfig, loadEnv } from '../config';
 import { pack } from 'repomix';
 import { readFileSync } from 'node:fs';
-import { FileError, RepoError, RepoAnalysisError } from '../errors';
+import { FileError, ProviderError } from '../errors';
 import type { ModelOptions, BaseModelProvider } from '../providers/base';
 import { GeminiProvider, OpenAIProvider, OpenRouterProvider } from '../providers/base';
 import { ModelNotFoundError } from '../errors';
@@ -72,7 +72,7 @@ export class RepoCommand implements Command {
       const model = options?.model || this.config?.repo?.model;
 
       if (!model) {
-        throw new RepoError(`No model specified for ${providerName}`);
+        throw new ProviderError(`No model specified for ${providerName}`);
       }
 
       yield `Analyzing repository using ${model}...\n`;
@@ -83,10 +83,10 @@ export class RepoCommand implements Command {
         });
         yield response;
       } catch (error) {
-        throw new RepoAnalysisError(error instanceof Error ? error.message : 'Unknown error during analysis', error);
+        throw new ProviderError(error instanceof Error ? error.message : 'Unknown error during analysis', error);
       }
     } catch (error) {
-      if (error instanceof RepoError || error instanceof FileError) {
+      if (error instanceof FileError || error instanceof ProviderError) {
         yield error.formatUserMessage(options?.debug);
       } else if (error instanceof Error) {
         yield `Error: ${error.message}\n`;

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -1,9 +1,13 @@
-import type { Command, CommandGenerator, CommandOptions } from '../types.ts';
-import type { Config } from '../config.ts';
-import { loadConfig, loadEnv } from '../config.ts';
-import { readFileSync } from 'node:fs';
+import type { Command, CommandGenerator, CommandOptions } from '../types';
+import type { Config } from '../config';
+import { loadConfig, loadEnv } from '../config';
 import { pack } from 'repomix';
-import { ignorePatterns, includePatterns, outputOptions } from '../repomix/repomixConfig.ts';
+import { readFileSync } from 'node:fs';
+import { FileError, RepoError, RepoAnalysisError } from '../errors';
+import type { ModelOptions, BaseModelProvider } from '../providers/base';
+import { GeminiProvider, OpenAIProvider, OpenRouterProvider } from '../providers/base';
+import { ModelNotFoundError } from '../errors';
+
 export class RepoCommand implements Command {
   private config: Config;
 
@@ -12,92 +16,128 @@ export class RepoCommand implements Command {
     this.config = loadConfig();
   }
 
-  private async fetchGeminiResponse(
-    query: string,
-    repoContext: string,
-    options?: CommandOptions
-  ): Promise<string> {
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      throw new Error('GEMINI_API_KEY environment variable is not set');
-    }
-
-    let cursorRules = '';
-    try {
-      cursorRules = readFileSync('.cursorrules', 'utf-8');
-    } catch {
-      // Ignore if .cursorrules doesn't exist
-    }
-
-    const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${options?.model || this.config.gemini.model}:generateContent?key=${apiKey}`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          contents: [
-            {
-              parts: [{ text: cursorRules }, { text: repoContext }, { text: query }],
-            },
-          ],
-          generationConfig: {
-            maxOutputTokens: options?.maxTokens || this.config.gemini.maxTokens,
-          },
-        }),
-      }
-    );
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Gemini API error (${response.status}): ${errorText}`);
-    }
-
-    const data = await response.json();
-    if (data.error) {
-      throw new Error(`Gemini API error: ${JSON.stringify(data.error, null, 2)}`);
-    }
-
-    return data.candidates[0].content.parts[0].text;
-  }
-
   async *execute(query: string, options?: CommandOptions): CommandGenerator {
     try {
       yield 'Packing repository using repomix...\n';
 
-      await pack(process.cwd(), {
-        output: {
-          ...outputOptions,
-          filePath: '.repomix-output.txt',
-        },
-        include: includePatterns,
-        ignore: {
-          useGitignore: true,
-          useDefaultPatterns: true,
-          customPatterns: ignorePatterns,
-        },
-        security: {
-          enableSecurityCheck: true,
-        },
-        tokenCount: {
-          encoding: this.config.tokenCount?.encoding || 'o200k_base',
-        },
-        cwd: process.cwd(),
-      });
+      try {
+        await pack(process.cwd(), {
+          output: {
+            filePath: '.repomix-output.txt',
+            style: 'plain',
+            parsableStyle: false,
+            fileSummary: false,
+            directoryStructure: true,
+            removeComments: false,
+            removeEmptyLines: true,
+            showLineNumbers: false,
+            copyToClipboard: false,
+            includeEmptyDirectories: false,
+            topFilesLength: 1000
+          },
+          include: ['**/*'],
+          ignore: {
+            useGitignore: true,
+            useDefaultPatterns: true,
+            customPatterns: []
+          },
+          security: {
+            enableSecurityCheck: true
+          },
+          tokenCount: {
+            encoding: this.config.tokenCount?.encoding || 'o200k_base'
+          },
+          cwd: process.cwd()
+        });
+      } catch (error) {
+        throw new FileError('Failed to pack repository', error);
+      }
 
-      const repoContext = readFileSync('.repomix-output.txt', 'utf-8');
+      let repoContext: string;
+      try {
+        repoContext = readFileSync('.repomix-output.txt', 'utf-8');
+      } catch (error) {
+        throw new FileError('Failed to read repository context', error);
+      }
 
-      const model = options?.model || this.config.gemini.model;
-      yield `Querying Gemini AI using ${model}...\n`;
-      const response = await this.fetchGeminiResponse(query, repoContext, options);
-      yield response;
+      let cursorRules = '';
+      try {
+        cursorRules = readFileSync('.cursorrules', 'utf-8');
+      } catch {
+        // Ignore if .cursorrules doesn't exist
+      }
+
+      const provider = createRepoProvider(options?.provider || this.config.repo?.provider || 'gemini');
+      const providerName = options?.provider || this.config.repo?.provider || 'gemini';
+      const model = options?.model || this.config?.repo?.model;
+
+      if (!model) {
+        throw new RepoError(`No model specified for ${providerName}`);
+      }
+
+      yield `Analyzing repository using ${model}...\n`;
+      try {
+        const response = await provider.analyzeRepository(query, repoContext, cursorRules, {
+          model,
+          maxTokens: options?.maxTokens || this.config.repo?.maxTokens
+        });
+        yield response;
+      } catch (error) {
+        throw new RepoAnalysisError(error instanceof Error ? error.message : 'Unknown error during analysis', error);
+      }
     } catch (error) {
-      if (error instanceof Error) {
-        yield `Error: ${error.message}`;
+      if (error instanceof RepoError || error instanceof FileError) {
+        yield error.formatUserMessage(options?.debug);
+      } else if (error instanceof Error) {
+        yield `Error: ${error.message}\n`;
       } else {
-        yield 'An unknown error occurred';
+        yield 'An unknown error occurred\n';
       }
     }
   }
+} 
+
+// Repository-specific provider interface
+export interface RepoModelProvider extends BaseModelProvider {
+  analyzeRepository(query: string, repoContext: string, cursorRules: string, options?: ModelOptions): Promise<string>;
 }
+
+// Shared mixin for repo providers
+const RepoProviderMixin = {
+  async analyzeRepository(this: BaseModelProvider, query: string, repoContext: string, cursorRules: string, options?: ModelOptions): Promise<string> {
+    return this.executePrompt(
+      `${cursorRules}\n\n${repoContext}\n\n${query}`,
+      {
+        ...options,
+        systemPrompt: 'You are an expert software developer analyzing a repository. Provide clear, actionable insights and recommendations.'
+      }
+    );
+  }
+};
+
+// Repository provider implementations
+export class RepoGeminiProvider extends GeminiProvider implements RepoModelProvider {
+  analyzeRepository = RepoProviderMixin.analyzeRepository;
+}
+
+export class RepoOpenAIProvider extends OpenAIProvider implements RepoModelProvider {
+  analyzeRepository = RepoProviderMixin.analyzeRepository;
+}
+
+export class RepoOpenRouterProvider extends OpenRouterProvider implements RepoModelProvider {
+  analyzeRepository = RepoProviderMixin.analyzeRepository;
+}
+
+// Factory function to create providers
+export function createRepoProvider(provider: 'gemini' | 'openai' | 'openrouter'): RepoModelProvider {
+  switch (provider) {
+    case 'gemini':
+      return new RepoGeminiProvider();
+    case 'openai':
+      return new RepoOpenAIProvider();
+    case 'openrouter':
+      return new RepoOpenRouterProvider();
+    default:
+      throw new ModelNotFoundError(provider);
+  }
+} 

--- a/src/commands/web.ts
+++ b/src/commands/web.ts
@@ -5,6 +5,13 @@ import { createEventSource } from 'eventsource-client';
 
 const MAX_RETRIES = 2;
 
+export async function queryPerplexity(
+  query: string,
+  options?: CommandOptions
+): Promise<string> {
+  // ... rest of function implementation ...
+}
+
 export class WebCommand implements Command {
   private config: Config;
 

--- a/src/commands/web.ts
+++ b/src/commands/web.ts
@@ -5,13 +5,6 @@ import { createEventSource } from 'eventsource-client';
 
 const MAX_RETRIES = 2;
 
-export async function queryPerplexity(
-  query: string,
-  options?: CommandOptions
-): Promise<string> {
-  // ... rest of function implementation ...
-}
-
 export class WebCommand implements Command {
   private config: Config;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import type { Provider } from './types';
+
 export interface Config {
   perplexity: {
     model: string;
@@ -9,8 +11,24 @@ export interface Config {
     apiKey?: string;
     maxTokens?: number;
   };
+  plan?: {
+    fileProvider: Provider;
+    thinkingProvider: Provider;
+    fileModel?: string;
+    thinkingModel?: string;
+    fileMaxTokens?: number;
+    thinkingMaxTokens?: number;
+  };
+  repo?: {
+    provider: Provider;
+    model?: string;
+    maxTokens?: number;
+  };
   doc?: {
     maxRepoSizeMB?: number; // Maximum repository size in MB for remote processing
+    provider: Provider;
+    model?: string;
+    maxTokens?: number;
   };
   tokenCount?: {
     encoding: 'o200k_base' | 'gpt2' | 'r50k_base' | 'p50k_base' | 'p50k_edit' | 'cl100k_base'; // The tokenizer encoding to use
@@ -37,16 +55,32 @@ export const defaultConfig: Config = {
     model: 'gemini-2.0-pro-exp-02-05',
     maxTokens: 10000,
   },
+  plan: {
+    fileProvider: 'gemini',
+    thinkingProvider: 'openrouter',
+    fileModel: 'gemini-2.0-pro-exp-02-05',
+    thinkingModel: 'deepseek/deepseek-r1',
+    fileMaxTokens: 8192,
+    thinkingMaxTokens: 8192,
+  },
+  repo: {
+    provider: 'gemini',
+    model: 'gemini-2.0-pro-exp-02-05',
+    maxTokens: 8192,
+  },
   doc: {
-    maxRepoSizeMB: 100, // Default to 100MB
+    maxRepoSizeMB: 100,
+    provider: 'gemini',
+    model: 'gemini-2.0-pro-exp-02-05',
+    maxTokens: 8192,
   },
   tokenCount: {
-    encoding: 'o200k_base', // Default to o200k_base as it's optimized for Gemini
+    encoding: 'o200k_base',
   },
   browser: {
     headless: true,
     defaultViewport: '1280x720',
-    timeout: 120000, // 120 seconds - stagehand needs a lot of time to go back and forward to LLMs
+    timeout: 120000,
   },
   stagehand: {
     provider: 'openai',

--- a/src/cursorrules.ts
+++ b/src/cursorrules.ts
@@ -18,6 +18,20 @@ globs:
 # Instructions
 Use the following commands to get AI assistance:
 
+**Implementation Planning:**
+\`cursor-tools plan "<query>"\` - Generate a focused implementation plan using AI (e.g., \`cursor-tools plan "Add user authentication to the login page"\`)
+The plan command uses multiple AI models to:
+1. Identify relevant files in your codebase
+2. Extract content from those files
+3. Generate a detailed implementation plan
+
+**Plan Command Options:**
+--fileProvider=<provider>: Provider for file identification (gemini, openai, or openrouter)
+--thinkingProvider=<provider>: Provider for plan generation (gemini, openai, or openrouter)
+--fileModel=<model>: Model to use for file identification
+--thinkingModel=<model>: Model to use for plan generation
+--debug: Show detailed error information
+
 **Web Search:**
 \`cursor-tools web "<your question>"\` - Get answers from the web using Perplexity AI (e.g., \`cursor-tools web "latest weather in London"\`)
 when using web for complex queries suggest writing the output to a file somewhere like local-research/<query summary>.md.
@@ -64,8 +78,16 @@ when using doc for remote repos suggest writing the output to a file somewhere l
 --save-to=<file path>: Save command output to a file (in *addition* to displaying it)
 --help: View all available options (help is not fully implemented yet)
 
+**Repository Command Options:**
+--provider=<provider>: AI provider to use (gemini, openai, or openrouter)
+--model=<model>: Model to use for repository analysis
+--max-tokens=<number>: Maximum tokens for response
+
 **Documentation Command Options:**
 --from-github=<GitHub username>/<repository name>[@<branch>]: Generate documentation for a remote GitHub repository
+--provider=<provider>: AI provider to use (gemini, openai, or openrouter)
+--model=<model>: Model to use for documentation generation
+--max-tokens=<number>: Maximum tokens for response
 
 **GitHub Command Options:**
 --from-github=<GitHub username>/<repository name>[@<branch>]: Access PRs/issues from a specific GitHub repository
@@ -99,6 +121,7 @@ Stagehand is a nickname for cursor-tools browser
 - repo has a limit of 2M tokens of context. The context can be reduced by filtering out files in a .repomixignore file.
 - problems running browser commands may be because playwright is not installed. Recommend installing playwright globally.
 - **Remember:** You're part of a team of superhuman expert AIs. Work together to solve complex problems.
+
 <!-- cursor-tools-version: ${CURSOR_RULES_VERSION} -->
 </cursor-tools Integration>`;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,131 @@
+// Error codes for common scenarios
+export enum ErrorCode {
+  API_KEY_MISSING = 'API_KEY_MISSING',
+  MODEL_NOT_FOUND = 'MODEL_NOT_FOUND',
+  NETWORK_ERROR = 'NETWORK_ERROR',
+  INVALID_CONFIG = 'INVALID_CONFIG',
+  PROVIDER_ERROR = 'PROVIDER_ERROR',
+  FILE_ERROR = 'FILE_ERROR',
+  REPO_ERROR = 'REPO_ERROR',
+  DOC_ERROR = 'DOC_ERROR',
+  PLAN_ERROR = 'PLAN_ERROR',
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR'
+}
+
+// Base error class for all cursor-tools errors
+export class CursorToolsError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ErrorCode,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'CursorToolsError';
+  }
+
+  // Format error message for user display
+  public formatUserMessage(debug = false): string {
+    let message = `${this.message}`;
+    
+    if (debug && this.details) {
+      message += `\nDetails: ${JSON.stringify(this.details, null, 2)}`;
+    }
+    
+    return message;
+  }
+}
+
+// Provider-related errors
+export class ProviderError extends CursorToolsError {
+  constructor(message: string, details?: unknown) {
+    super(message, ErrorCode.PROVIDER_ERROR, details);
+    this.name = 'ProviderError';
+  }
+}
+
+export class ApiKeyMissingError extends ProviderError {
+  constructor(provider: string) {
+    super(
+      `API key for ${provider} is not set. Please set the ${provider.toUpperCase()}_API_KEY environment variable.`,
+      { provider }
+    );
+    this.name = 'ApiKeyMissingError';
+  }
+}
+
+export class ModelNotFoundError extends ProviderError {
+  constructor(provider: string, model?: string) {
+    super(
+      `No model specified for ${provider}${model ? ` (requested model: ${model})` : ''}.`,
+      { provider, model }
+    );
+    this.name = 'ModelNotFoundError';
+  }
+}
+
+export class NetworkError extends ProviderError {
+  constructor(message: string, details?: unknown) {
+    super(`Network error: ${message}`, details);
+    this.name = 'NetworkError';
+  }
+}
+
+// File-related errors
+export class FileError extends CursorToolsError {
+  constructor(message: string, details?: unknown) {
+    super(message, ErrorCode.FILE_ERROR, details);
+    this.name = 'FileError';
+  }
+}
+
+// Repository-related errors
+export class RepoError extends CursorToolsError {
+  constructor(message: string, details?: unknown) {
+    super(message, ErrorCode.REPO_ERROR, details);
+    this.name = 'RepoError';
+  }
+}
+
+export class RepoAnalysisError extends RepoError {
+  constructor(message: string, details?: unknown) {
+    super(`Failed to analyze repository: ${message}`, details);
+    this.name = 'RepoAnalysisError';
+  }
+}
+
+// Documentation-related errors
+export class DocError extends CursorToolsError {
+  constructor(message: string, details?: unknown) {
+    super(message, ErrorCode.DOC_ERROR, details);
+    this.name = 'DocError';
+  }
+}
+
+export class DocGenerationError extends DocError {
+  constructor(message: string, details?: unknown) {
+    super(`Failed to generate documentation: ${message}`, details);
+    this.name = 'DocGenerationError';
+  }
+}
+
+// Plan-related errors
+export class PlanError extends CursorToolsError {
+  constructor(message: string, details?: unknown) {
+    super(message, ErrorCode.PLAN_ERROR, details);
+    this.name = 'PlanError';
+  }
+}
+
+export class FileFilterError extends PlanError {
+  constructor(message: string, details?: unknown) {
+    super(`Failed to identify relevant files: ${message}`, details);
+    this.name = 'FileFilterError';
+  }
+}
+
+export class PlanGenerationError extends PlanError {
+  constructor(message: string, details?: unknown) {
+    super(`Failed to generate implementation plan: ${message}`, details);
+    this.name = 'PlanGenerationError';
+  }
+} 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,24 +1,6 @@
-// Error codes for common scenarios
-export enum ErrorCode {
-  API_KEY_MISSING = 'API_KEY_MISSING',
-  MODEL_NOT_FOUND = 'MODEL_NOT_FOUND',
-  NETWORK_ERROR = 'NETWORK_ERROR',
-  INVALID_CONFIG = 'INVALID_CONFIG',
-  PROVIDER_ERROR = 'PROVIDER_ERROR',
-  FILE_ERROR = 'FILE_ERROR',
-  REPO_ERROR = 'REPO_ERROR',
-  DOC_ERROR = 'DOC_ERROR',
-  PLAN_ERROR = 'PLAN_ERROR',
-  UNKNOWN_ERROR = 'UNKNOWN_ERROR'
-}
-
 // Base error class for all cursor-tools errors
 export class CursorToolsError extends Error {
-  constructor(
-    message: string,
-    public readonly code: ErrorCode,
-    public readonly details?: unknown
-  ) {
+  constructor(message: string, public readonly details?: unknown) {
     super(message);
     this.name = 'CursorToolsError';
   }
@@ -38,7 +20,7 @@ export class CursorToolsError extends Error {
 // Provider-related errors
 export class ProviderError extends CursorToolsError {
   constructor(message: string, details?: unknown) {
-    super(message, ErrorCode.PROVIDER_ERROR, details);
+    super(message);
     this.name = 'ProviderError';
   }
 }
@@ -73,59 +55,7 @@ export class NetworkError extends ProviderError {
 // File-related errors
 export class FileError extends CursorToolsError {
   constructor(message: string, details?: unknown) {
-    super(message, ErrorCode.FILE_ERROR, details);
+    super(message);
     this.name = 'FileError';
   }
 }
-
-// Repository-related errors
-export class RepoError extends CursorToolsError {
-  constructor(message: string, details?: unknown) {
-    super(message, ErrorCode.REPO_ERROR, details);
-    this.name = 'RepoError';
-  }
-}
-
-export class RepoAnalysisError extends RepoError {
-  constructor(message: string, details?: unknown) {
-    super(`Failed to analyze repository: ${message}`, details);
-    this.name = 'RepoAnalysisError';
-  }
-}
-
-// Documentation-related errors
-export class DocError extends CursorToolsError {
-  constructor(message: string, details?: unknown) {
-    super(message, ErrorCode.DOC_ERROR, details);
-    this.name = 'DocError';
-  }
-}
-
-export class DocGenerationError extends DocError {
-  constructor(message: string, details?: unknown) {
-    super(`Failed to generate documentation: ${message}`, details);
-    this.name = 'DocGenerationError';
-  }
-}
-
-// Plan-related errors
-export class PlanError extends CursorToolsError {
-  constructor(message: string, details?: unknown) {
-    super(message, ErrorCode.PLAN_ERROR, details);
-    this.name = 'PlanError';
-  }
-}
-
-export class FileFilterError extends PlanError {
-  constructor(message: string, details?: unknown) {
-    super(`Failed to identify relevant files: ${message}`, details);
-    this.name = 'FileFilterError';
-  }
-}
-
-export class PlanGenerationError extends PlanError {
-  constructor(message: string, details?: unknown) {
-    super(`Failed to generate implementation plan: ${message}`, details);
-    this.name = 'PlanGenerationError';
-  }
-} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,12 +18,18 @@ function toKebabCase(str: string): string {
   return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 }
 
-type StringOption =
+// CLI option types
+type CLIStringOption =
+  // Core options
   | 'model'
-  | 'fromGithub'
+  | 'provider'
+  // Output options
   | 'output'
   | 'saveTo'
+  // Context options
   | 'hint'
+  | 'fromGithub'
+  // Browser options
   | 'url'
   | 'screenshot'
   | 'viewport'
@@ -31,20 +37,46 @@ type StringOption =
   | 'wait'
   | 'video'
   | 'evaluate'
+  // Plan options
   | 'fileProvider'
   | 'thinkingProvider'
   | 'fileModel'
   | 'thinkingModel';
-type NumberOption = 'maxTokens' | 'timeout' | 'connectTo';
-type BooleanOption = 'console' | 'html' | 'network' | 'headless' | 'text' | 'debug';
 
-interface Options {
-  // String options
+type CLINumberOption = 
+  // Core options
+  | 'maxTokens'
+  // Browser options
+  | 'timeout'
+  | 'connectTo';
+
+type CLIBooleanOption = 
+  // Core options
+  | 'debug'
+  // Browser options
+  | 'console'
+  | 'html'
+  | 'network'
+  | 'headless'
+  | 'text';
+
+// Main CLI options interface
+interface CLIOptions {
+  // Core options
   model?: string;
-  fromGithub?: string;
+  provider?: string;
+  maxTokens?: number;
+  debug?: boolean;
+
+  // Output options
   output?: string;
   saveTo?: string;
+
+  // Context options
   hint?: string;
+  fromGithub?: string;
+
+  // Browser options
   url?: string;
   screenshot?: string;
   viewport?: string;
@@ -52,69 +84,78 @@ interface Options {
   wait?: string;
   video?: string;
   evaluate?: string;
-  // Plan command options
-  fileProvider?: string;
-  thinkingProvider?: string;
-  fileModel?: string;
-  thinkingModel?: string;
-  // Number options
-  maxTokens?: number;
   timeout?: number;
   connectTo?: number;
-  // Boolean options
   console?: boolean;
   html?: boolean;
   network?: boolean;
   headless?: boolean;
   text?: boolean;
-  debug?: boolean;
+
+  // Plan options
+  fileProvider?: string;
+  thinkingProvider?: string;
+  fileModel?: string;
+  thinkingModel?: string;
 }
 
-type OptionKey = StringOption | NumberOption | BooleanOption;
+type CLIOptionKey = CLIStringOption | CLINumberOption | CLIBooleanOption;
 
 // Map of normalized keys to their option names in the options object
-const OPTION_KEYS: Record<string, OptionKey> = {
+const OPTION_KEYS: Record<string, CLIOptionKey> = {
+  // Core options
   model: 'model',
+  provider: 'provider',
   maxtokens: 'maxTokens',
+  debug: 'debug',
+
+  // Output options
   output: 'output',
   saveto: 'saveTo',
-  fromgithub: 'fromGithub',
+
+  // Context options
   hint: 'hint',
-  // Browser command options
+  fromgithub: 'fromGithub',
+
+  // Browser options
   url: 'url',
-  console: 'console',
-  html: 'html',
   screenshot: 'screenshot',
-  network: 'network',
-  timeout: 'timeout',
   viewport: 'viewport',
-  headless: 'headless',
-  connectto: 'connectTo',
   selector: 'selector',
-  text: 'text',
   wait: 'wait',
-  debug: 'debug',
   video: 'video',
   evaluate: 'evaluate',
-  // Plan command options
+  timeout: 'timeout',
+  connectto: 'connectTo',
+  console: 'console',
+  html: 'html',
+  network: 'network',
+  headless: 'headless',
+  text: 'text',
+
+  // Plan options
   fileprovider: 'fileProvider',
   thinkingprovider: 'thinkingProvider',
   filemodel: 'fileModel',
   thinkingmodel: 'thinkingModel',
 };
 
-// Set of option keys that are boolean flags (don't require a value)
-const BOOLEAN_OPTIONS = new Set<BooleanOption>([
+// Set of option keys that are boolean flags
+const BOOLEAN_OPTIONS = new Set<CLIBooleanOption>([
+  'debug',
   'console',
   'html',
   'network',
   'headless',
-  'text',
-  'debug',
+  'text'
 ]);
 
 // Set of option keys that require numeric values
-const NUMERIC_OPTIONS = new Set<NumberOption>(['maxTokens', 'timeout', 'connectTo']);
+const NUMERIC_OPTIONS = new Set<CLINumberOption>([
+  'maxTokens',
+  'timeout',
+  'connectTo'
+]);
 
 async function main() {
   const [, , command, ...args] = process.argv;
@@ -133,7 +174,7 @@ async function main() {
   }
 
   // Parse options from args
-  const options: Options = {
+  const options: CLIOptions = {
     // String options
     model: undefined,
     fromGithub: undefined,
@@ -186,7 +227,7 @@ async function main() {
           key = arg.slice(5); // Remove --no- prefix
           const normalizedKey = normalizeArgKey(key.toLowerCase());
           const optionKey = OPTION_KEYS[normalizedKey];
-          if (BOOLEAN_OPTIONS.has(optionKey as BooleanOption)) {
+          if (BOOLEAN_OPTIONS.has(optionKey as CLIBooleanOption)) {
             value = 'false'; // Implicitly set boolean flag to false
             isNoPrefix = true;
           } else {
@@ -200,7 +241,7 @@ async function main() {
         // For boolean flags without --no- prefix, check next argument for explicit true/false
         const normalizedKey = normalizeArgKey(key.toLowerCase());
         const optionKey = OPTION_KEYS[normalizedKey];
-        if (!isNoPrefix && BOOLEAN_OPTIONS.has(optionKey as BooleanOption)) {
+        if (!isNoPrefix && BOOLEAN_OPTIONS.has(optionKey as CLIBooleanOption)) {
           // Check if next argument is 'true' or 'false'
           if (i + 1 < args.length && ['true', 'false'].includes(args[i + 1].toLowerCase())) {
             value = args[i + 1].toLowerCase();
@@ -232,25 +273,25 @@ async function main() {
         process.exit(1);
       }
 
-      if (value === undefined && !BOOLEAN_OPTIONS.has(optionKey as BooleanOption)) {
+      if (value === undefined && !BOOLEAN_OPTIONS.has(optionKey as CLIBooleanOption)) {
         console.error(`Error: No value provided for option '--${key}'`);
         process.exit(1);
       }
 
-      if (NUMERIC_OPTIONS.has(optionKey as NumberOption)) {
+      if (NUMERIC_OPTIONS.has(optionKey as CLINumberOption)) {
         const num = Number.parseInt(value || '', 10);
         if (Number.isNaN(num)) {
           console.error(`Error: ${optionKey} must be a number`);
           process.exit(1);
         }
-        options[optionKey as NumberOption] = num;
+        options[optionKey as CLINumberOption] = num;
         continue;
       }
 
-      if (BOOLEAN_OPTIONS.has(optionKey as BooleanOption)) {
-        options[optionKey as BooleanOption] = value === 'true';
+      if (BOOLEAN_OPTIONS.has(optionKey as CLIBooleanOption)) {
+        options[optionKey as CLIBooleanOption] = value === 'true';
       } else if (value !== undefined) {
-        options[optionKey as StringOption] = value;
+        options[optionKey as CLIStringOption] = value;
       }
     } else {
       queryArgs.push(arg);
@@ -323,8 +364,9 @@ async function main() {
     // Execute the command and handle output
     const commandOptions: CommandOptions = {
       ...options,
+      provider: options.provider as Provider,
       fileProvider: options.fileProvider as Provider,
-      thinkingProvider: options.thinkingProvider as Provider,
+      thinkingProvider: options.thinkingProvider as Provider
     };
     for await (const output of commandHandler.execute(query, commandOptions)) {
       process.stdout.write(output);

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -1,0 +1,223 @@
+import type { Config } from '../config';
+import { loadConfig, loadEnv } from '../config';
+import OpenAI from 'openai';
+import { ApiKeyMissingError, ModelNotFoundError, NetworkError, ProviderError } from '../errors';
+
+// Common options for all providers
+export interface ModelOptions {
+  model?: string;
+  maxTokens?: number;
+  systemPrompt?: string;
+  tokenCount?: number; // For handling large token counts
+}
+
+// Provider configuration in Config
+export interface ProviderConfig {
+  model?: string;
+  maxTokens?: number;
+  apiKey?: string;
+  // OpenRouter-specific fields
+  referer?: string;
+  appName?: string;
+}
+
+// Base provider interface that all specific provider interfaces will extend
+export interface BaseModelProvider {
+  executePrompt(prompt: string, options?: ModelOptions): Promise<string>;
+}
+
+// Base provider class with common functionality
+export abstract class BaseProvider implements BaseModelProvider {
+  protected config: Config;
+
+  constructor() {
+    loadEnv();
+    this.config = loadConfig();
+  }
+
+  protected getModel(options: ModelOptions | undefined): string {
+    if (!options?.model) {
+      throw new ModelNotFoundError(this.constructor.name.replace('Provider', ''));
+    }
+    return options.model;
+  }
+
+  protected getMaxTokens(options: ModelOptions | undefined): number {
+    return options?.maxTokens || 4000; // Default to 4000 if not specified
+  }
+
+  protected abstract getSystemPrompt(options?: ModelOptions): string | undefined;
+
+  protected handleLargeTokenCount(tokenCount: number): { model?: string; error?: string } {
+    return {}; // Default implementation - no token count handling
+  }
+
+  abstract executePrompt(prompt: string, options?: ModelOptions): Promise<string>;
+}
+
+// Gemini provider implementation
+export class GeminiProvider extends BaseProvider {
+  protected getSystemPrompt(): string | undefined {
+    return undefined; // Gemini doesn't use system prompts
+  }
+
+  protected handleLargeTokenCount(tokenCount: number): { model?: string; error?: string } {
+    if (tokenCount > 800_000 && tokenCount < 2_000_000) {
+      console.error(
+        `Repository content is large (${Math.round(tokenCount / 1000)}K tokens), switching to gemini-2.0-pro-exp-02-05 model...`
+      );
+      return { model: 'gemini-2.0-pro-exp-02-05' };
+    }
+    
+    if (tokenCount >= 2_000_000) {
+      return {
+        error: 'Repository content is too large for Gemini API.\n' +
+          'Please try:\n' +
+          '1. Using a more specific query to document a particular feature or module\n' +
+          '2. Running the documentation command on a specific directory or file\n' +
+          '3. Cloning the repository locally and using .gitignore to exclude non-essential files'
+      };
+    }
+    
+    return {};
+  }
+
+  async executePrompt(prompt: string, options?: ModelOptions): Promise<string> {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new ApiKeyMissingError('Gemini');
+    }
+
+    // Handle token count if provided
+    let finalOptions = { ...options };
+    if (options?.tokenCount) {
+      const { model: tokenModel, error } = this.handleLargeTokenCount(options.tokenCount);
+      if (error) {
+        throw new ProviderError(error);
+      }
+      if (tokenModel) {
+        finalOptions = { ...finalOptions, model: tokenModel };
+      }
+    }
+
+    const model = this.getModel(finalOptions);
+    const maxTokens = this.getMaxTokens(finalOptions);
+
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+            generationConfig: { maxOutputTokens: maxTokens },
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new NetworkError(`Gemini API error: ${await response.text()}`);
+      }
+
+      const data = await response.json();
+      if (data.error) {
+        throw new ProviderError(`Gemini API error: ${JSON.stringify(data.error)}`);
+      }
+
+      const content = data.candidates[0]?.content?.parts[0]?.text;
+      if (!content) {
+        throw new ProviderError('Gemini returned an empty response');
+      }
+
+      return content;
+    } catch (error) {
+      if (error instanceof ProviderError) {
+        throw error;
+      }
+      throw new NetworkError('Failed to communicate with Gemini API', error);
+    }
+  }
+}
+
+// Base class for OpenAI-compatible providers (OpenAI and OpenRouter)
+abstract class OpenAIBase extends BaseProvider {
+  protected client: OpenAI;
+
+  constructor(apiKey: string, baseURL?: string) {
+    super();
+    this.client = new OpenAI({
+      apiKey,
+      ...(baseURL ? { baseURL } : {})
+    });
+  }
+
+  protected getSystemPrompt(options?: ModelOptions): string | undefined {
+    return options?.systemPrompt || 'You are a helpful assistant. Provide clear and concise responses.';
+  }
+
+  async executePrompt(prompt: string, options?: ModelOptions): Promise<string> {
+    const model = this.getModel(options);
+    const maxTokens = this.getMaxTokens(options);
+    const systemPrompt = this.getSystemPrompt(options);
+
+    try {
+      const response = await this.client.chat.completions.create({
+        model,
+        messages: [
+          ...(systemPrompt ? [{ role: 'system' as const, content: systemPrompt }] : []),
+          { role: 'user' as const, content: prompt }
+        ],
+        max_tokens: maxTokens,
+      });
+
+      const content = response.choices[0].message.content;
+      if (!content) {
+        throw new ProviderError(`${this.constructor.name} returned an empty response`);
+      }
+
+      return content;
+    } catch (error) {
+      if (error instanceof ProviderError) {
+        throw error;
+      }
+      throw new NetworkError(`Failed to communicate with ${this.constructor.name} API`, error);
+    }
+  }
+}
+
+// OpenAI provider implementation
+export class OpenAIProvider extends OpenAIBase {
+  constructor() {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new ApiKeyMissingError('OpenAI');
+    }
+    super(apiKey);
+  }
+}
+
+// OpenRouter provider implementation
+export class OpenRouterProvider extends OpenAIBase {
+  constructor() {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      throw new ApiKeyMissingError('OpenRouter');
+    }
+    super(apiKey, 'https://openrouter.ai/api/v1');
+  }
+}
+
+// Factory function to create providers
+export function createProvider(provider: 'gemini' | 'openai' | 'openrouter'): BaseModelProvider {
+  switch (provider) {
+    case 'gemini':
+      return new GeminiProvider();
+    case 'openai':
+      return new OpenAIProvider();
+    case 'openrouter':
+      return new OpenRouterProvider();
+    default:
+      throw new Error(`Unknown provider: ${provider}`);
+  }
+} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,21 @@ export type CommandGenerator = AsyncGenerator<string, void, unknown>;
 
 export type Provider = 'gemini' | 'openai' | 'openrouter';
 
+// Base options shared by all commands
 export interface CommandOptions {
+  // Core options
   model?: string;
   maxTokens?: number;
+  provider?: Provider;
+  debug?: boolean;
+  url?: string;
+  
+  // Output options
   saveTo?: string; // Path to save output to in addition to stdout
+  
+  // Context options
   hint?: string; // Additional context or hint for the AI
-  url?: string; // URL for browser commands
-  debug?: boolean; // Enable debug output
-  provider?: Provider; // AI provider to use
+  
   // Plan command specific options
   fileProvider?: Provider;
   thinkingProvider?: Provider;
@@ -39,6 +46,11 @@ export interface Config {
     fileMaxTokens?: number;
     thinkingMaxTokens?: number;
   };
+  gemini: {
+    model: string;
+    apiKey?: string;
+    maxTokens?: number;
+  }
   repo?: {
     provider: Provider;
     model?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type CommandGenerator = AsyncGenerator<string, void, unknown>;
 
+export type Provider = 'gemini' | 'openai' | 'openrouter';
+
 export interface CommandOptions {
   model?: string;
   maxTokens?: number;
@@ -7,6 +9,12 @@ export interface CommandOptions {
   hint?: string; // Additional context or hint for the AI
   url?: string; // URL for browser commands
   debug?: boolean; // Enable debug output
+  provider?: Provider; // AI provider to use
+  // Plan command specific options
+  fileProvider?: Provider;
+  thinkingProvider?: Provider;
+  fileModel?: string;
+  thinkingModel?: string;
 }
 
 export interface Command {
@@ -23,12 +31,37 @@ export interface Config {
     apiKey?: string;
     maxTokens?: number;
   };
-  gemini: {
-    model: string;
-    apiKey?: string;
+  plan?: {
+    fileProvider: Provider;
+    thinkingProvider: Provider;
+    fileModel?: string;
+    thinkingModel?: string;
+    fileMaxTokens?: number;
+    thinkingMaxTokens?: number;
+  };
+  repo?: {
+    provider: Provider;
+    model?: string;
     maxTokens?: number;
   };
   doc?: {
     maxRepoSizeMB?: number; // Maximum repository size in MB for remote processing
+    provider: Provider;
+    model?: string;
+    maxTokens?: number;
+  };
+  tokenCount?: {
+    encoding: 'o200k_base' | 'gpt2' | 'r50k_base' | 'p50k_base' | 'p50k_edit' | 'cl100k_base';
+  };
+  browser?: {
+    headless?: boolean;
+    defaultViewport?: string;
+    timeout?: number;
+  };
+  stagehand?: {
+    provider: 'anthropic' | 'openai';
+    verbose?: boolean;
+    debugDom?: boolean;
+    enableCaching?: boolean;
   };
 }

--- a/src/types/browser/browser.ts
+++ b/src/types/browser/browser.ts
@@ -1,5 +1,4 @@
 import type { z } from 'zod';
-import type { Provider } from '../../types';
 
 // Core Stagehand API interface
 export interface Stagehand {
@@ -17,13 +16,13 @@ export interface StagehandConfig {
   enableCaching: boolean;
   browserbaseApiKey?: string;
   browserbaseProjectId?: string;
-  llmProvider?: StagehandProvider;
+  llmProvider?: LLMProvider;
   openaiApiKey?: string;
   anthropicApiKey?: string;
   googleApiKey?: string;
 }
 
-export type StagehandProvider = 'openai' | 'anthropic' | 'google';
+export type LLMProvider = 'openai' | 'anthropic' | 'google';
 
 // Stagehand method options
 export interface ActOptions {

--- a/src/types/browser/browser.ts
+++ b/src/types/browser/browser.ts
@@ -1,4 +1,5 @@
-import { z } from 'zod';
+import type { z } from 'zod';
+import type { Provider } from '../../types';
 
 // Core Stagehand API interface
 export interface Stagehand {
@@ -16,13 +17,13 @@ export interface StagehandConfig {
   enableCaching: boolean;
   browserbaseApiKey?: string;
   browserbaseProjectId?: string;
-  llmProvider?: LLMProvider;
+  llmProvider?: StagehandProvider;
   openaiApiKey?: string;
   anthropicApiKey?: string;
   googleApiKey?: string;
 }
 
-export type LLMProvider = 'openai' | 'anthropic' | 'google';
+export type StagehandProvider = 'openai' | 'anthropic' | 'google';
 
 // Stagehand method options
 export interface ActOptions {

--- a/tests/commands/browser/serve.ts
+++ b/tests/commands/browser/serve.ts
@@ -12,7 +12,7 @@
 
 import { join } from 'node:path';
 
-const port = process.env['PORT'] || 3000;
+const port = process.env?.PORT ?? 3000;
 console.log(`Starting server on http://localhost:${port}`);
 
 Bun.serve({


### PR DESCRIPTION
This introduces several changes, so it may be too large for one PR, but i figured i'd give it a shot:
1. Adds the `plan` command 
2. Adds openrouter and openai support to the doc, repo, and plan commands, allowing a per command configuration of the model and provider
3. Refactors some typing 

AI summary:

Enhance functionality by integrating support for the OpenAI and OpenRouter models across multiple components. These changes ensure broader compatibility and improved plan generation capabilities.

- Updated .cursor-tools.env.example to include new API keys
- Expanded cursorrules to detail plan command options
- Modified CHANGELOG.md to document additions and changes
- Enhanced README.md with configuration options
- Refined cursor-tools.config.json for plan settings
- Added local research documents on OpenAI integration
- Updated package.json with new dependencies
- Refactored TypeScript commands and providers
- Incorporated new error handling mechanisms
- Updated the overall configuration structure