### PR TITLE
Fix: Add USE_LEGACY env var as workaround for Cursor bug

### DIFF
--- a/.cursor-tools.env.example
+++ b/.cursor-tools.env.example
@@ -1,2 +1,5 @@
 PERPLEXITY_API_KEY="your-api-key-here"
 GEMINI_API_KEY="your-api-key-here"
+
+# Optional: Set to 'true' to use legacy .cursorrules file instead of .cursor/rules/cursor-tools.mdc
+# USE_LEGACY=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ All notable changes to this project will be documented in this file.
 - Improved page reuse in browser commands when using `--connect-to`: now reuses existing tabs instead of creating new ones for better state preservation
 - Improved error handling and type safety in cursor rules management
 - Enhanced directory creation order in installation process
+- Added user choice during installation for cursor rules location (legacy `.cursorrules` or new `.cursor/rules/cursor-tools.mdc`)
+- Added `USE_LEGACY` environment variable to control cursor rules file location
 
 ### Added
 - Support for new Cursor IDE project rules structure
-  - New installations now use `.cursor/rules/cursor-tools.mdc`
-  - Maintain compatibility with legacy `.cursorrules` file
-  - When both exist, prefer new path and show warning
+  - New installations now use `.cursor/rules/cursor-tools.mdc` by default
+  - Maintain compatibility with legacy `.cursorrules` file via `USE_LEGACY=true`
+  - Interactive choice during installation
+  - When both exist, use path based on `USE_LEGACY` environment variable
   - Updated documentation to reflect new path structure
 - Added support for the `gpt-4o` model in browser commands (`act`, `extract`, `observe`)
   - The model can be selected using the `--model=gpt-4o` command-line option

--- a/README.md
+++ b/README.md
@@ -76,7 +76,14 @@ Here are two examples:
 
 ## What is cursor-tools
 
-`cursor-tools` provides a CLI that your **AI agent can use** to expand its capabilities. `cursor-tools` works with with Cursor (and is compatible with other agents), When you run `cursor-tools install` we automatically add a prompt section to your Cursor project rules (`.cursor/rules/cursor-tools.mdc` or legacy `.cursorrules` file) so that it works out of the box with Cursor, there's no need for additional prompts.
+`cursor-tools` provides a CLI that your **AI agent can use** to expand its capabilities. `cursor-tools` works with with Cursor (and is compatible with other agents), When you run `cursor-tools install` we automatically add a prompt section to your Cursor project rules. During installation, you can choose between:
+- The new `.cursor/rules/cursor-tools.mdc` file (recommended)
+- The legacy `.cursorrules` file (for backward compatibility)
+
+You can also control this using the `USE_LEGACY` environment variable:
+- `USE_LEGACY=true` - Use legacy `.cursorrules` file
+- `USE_LEGACY=false` - Use new `.cursor/rules/cursor-tools.mdc` file
+- If not set, defaults to legacy mode for backward compatibility
 
 `cursor-tools` requires a Perplexity API key and a Google AI API key.
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -24,6 +24,23 @@ async function getUserInput(prompt: string): Promise<string> {
   });
 }
 
+// Add this function after the getUserInput function
+async function askForCursorRulesDirectory(): Promise<boolean> {
+  // If USE_LEGACY is explicitly set, respect that setting
+  if (process.env.USE_LEGACY === 'true') {
+    return false;
+  }
+  if (process.env.USE_LEGACY === 'false') {
+    return true;
+  }
+
+  // Otherwise, ask the user
+  const answer = await getUserInput(
+    'Would you like to use the new .cursor/rules directory for cursor rules? (y/N): '
+  );
+  return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+}
+
 export class InstallCommand implements Command {
   private async *setupApiKeys(): CommandGenerator {
     loadEnv(); // Load existing env files if any
@@ -202,6 +219,11 @@ export class InstallCommand implements Command {
     // 4. Update/create cursor rules
     try {
       yield 'Checking cursor rules...\n';
+      
+      // Ask user for directory preference
+      const useNewDirectory = await askForCursorRulesDirectory();
+      process.env.USE_LEGACY = (!useNewDirectory).toString();
+      
       const result = checkCursorRules(absolutePath);
 
       if (result.kind === 'error') {
@@ -213,9 +235,24 @@ export class InstallCommand implements Command {
       let needsUpdate = result.needsUpdate;
 
       if (result.hasLegacyCursorRulesFile) {
-        yield '\n🚧 Warning: Legacy .cursorrules detected. This file will be deprecated in a future release. To migrate:\n' +
-          '  1) Move your rules to .cursor/rules/cursor-tools.mdc\n' +
-          '  2) Delete .cursorrules\n\n';
+        yield '\n🚧 Warning: Using legacy .cursorrules file. This file will be deprecated in a future release.\n' +
+          'To migrate to the new format:\n' +
+          '  1) Set USE_LEGACY=false in your environment\n' +
+          '  2) Run cursor-tools install . again\n' +
+          '  3) Delete .cursorrules once you confirm everything works\n\n';
+      }
+
+      // Create directories if using new path
+      if (!result.hasLegacyCursorRulesFile) {
+        const rulesDir = join(absolutePath, '.cursor', 'rules');
+        if (!existsSync(rulesDir)) {
+          try {
+            mkdirSync(rulesDir, { recursive: true });
+          } catch (error) {
+            yield `Error creating rules directory: ${error instanceof Error ? error.message : 'Unknown error'}\n`;
+            return;
+          }
+        }
       }
 
       if (existsSync(result.targetPath)) {

--- a/src/cursorrules.ts
+++ b/src/cursorrules.ts
@@ -9,6 +9,19 @@ const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'
 
 export const CURSOR_RULES_VERSION = packageJson.version; // Using version from package.json
 
+// Function to determine which cursor rules path to use
+export function getCursorRulesPath(workspacePath: string): { targetPath: string; isLegacy: boolean } {
+  const useLegacy = process.env.USE_LEGACY === 'true' || !process.env.USE_LEGACY;
+  const legacyPath = join(workspacePath, '.cursorrules');
+  const newPath = join(workspacePath, '.cursor', 'rules', 'cursor-tools.mdc');
+
+  if (useLegacy) {
+    return { targetPath: legacyPath, isLegacy: true };
+  }
+
+  return { targetPath: newPath, isLegacy: false };
+}
+
 export const CURSOR_RULES_TEMPLATE = `---
 description: Global Rule
 globs: 
@@ -145,64 +158,36 @@ type CursorRulesSuccess = {
 type CursorRulesResult = CursorRulesError | CursorRulesSuccess;
 
 export function checkCursorRules(workspacePath: string): CursorRulesResult {
-  const legacyPath = join(workspacePath, '.cursorrules');
-  const newPath = join(workspacePath, '.cursor', 'rules', 'cursor-tools.mdc');
+  const { targetPath, isLegacy } = getCursorRulesPath(workspacePath);
 
-  // Check if either file exists
-  const legacyExists = existsSync(legacyPath);
-  const newExists = existsSync(newPath);
+  // Check if the file exists
+  const exists = existsSync(targetPath);
 
-  // If neither exists, prefer new path
-  if (!legacyExists && !newExists) {
+  if (!exists) {
     return {
       kind: 'success',
       needsUpdate: true,
       message:
         'No cursor rules file found. Run `cursor-tools install .` to set up Cursor integration.',
-      targetPath: newPath,
-      hasLegacyCursorRulesFile: false,
+      targetPath,
+      hasLegacyCursorRulesFile: isLegacy,
     };
   }
 
   try {
-    // If both exist, check new path first
-    if (newExists && legacyExists) {
-      const newContent = readFileSync(newPath, 'utf-8');
-      const result = isCursorRulesContentUpToDate(newContent);
-      return {
-        kind: 'success',
-        ...result,
-        targetPath: newPath,
-        hasLegacyCursorRulesFile: true,
-      };
-    }
-
-    // If only new path exists
-    if (newExists) {
-      const newContent = readFileSync(newPath, 'utf-8');
-      const result = isCursorRulesContentUpToDate(newContent);
-      return {
-        kind: 'success',
-        ...result,
-        targetPath: newPath,
-        hasLegacyCursorRulesFile: false,
-      };
-    }
-
-    // Otherwise only legacy path exists
-    const legacyContent = readFileSync(legacyPath, 'utf-8');
-    const result = isCursorRulesContentUpToDate(legacyContent);
+    const content = readFileSync(targetPath, 'utf-8');
+    const result = isCursorRulesContentUpToDate(content);
     return {
       kind: 'success',
       ...result,
-      targetPath: legacyPath,
-      hasLegacyCursorRulesFile: true,
+      targetPath,
+      hasLegacyCursorRulesFile: isLegacy,
     };
   } catch (error) {
     return {
       kind: 'error',
       message: `Error reading cursor rules: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      targetPath: newPath,
+      targetPath,
     };
   }
 }


### PR DESCRIPTION
The [Project Rules](https://docs.cursor.com/context/rules-for-ai#project-rules-recommended) (.cursor/rules directory) on Cursor is not working as intended. However, they are moving towards using it, and eventually stop using the `.cursorrules` file.

`cursor-tools` is already adapted to use the [Project Rules](https://docs.cursor.com/context/rules-for-ai#project-rules-recommended) on fresh installs, and we don't want to lose that (since Cursor ir walking towards that).

But, since it is not working as intended, this PR proposes an workaround. It uses an env var called `USE_LEGACY`.

- When USE_LEGACY=true, we use the .cursorrules file
- When USE_LEGACY=false, we use the [Project Rules](https://docs.cursor.com/context/rules-for-ai#project-rules-recommended) (.cursor/rules directory)
- When USE_LEGACY is empty, we prompt the user during installation
  - Of course, follow user instruction
  - If user skips, we default to using the .cursorrules file

My idea is to quickly workaround Cursor bug, but at the same time make the code flexible enough to force back the [Project Rules](https://docs.cursor.com/context/rules-for-ai#project-rules-recommended) (.cursor/rules directory) when it starts working.