### PR TITLE
feat: enhance doc command to handle query as repo or hint

### DIFF
--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -314,8 +314,6 @@ Please:
         return;
       }
 
-      let repoContext: { text: string; tokenCount: number };
-      
       const providerName = options?.provider || this.config.doc?.provider || 'openai';
       const model =
         options?.model ||


### PR DESCRIPTION
Enhances doc command to handle query parameter more intelligently: as a repo reference if it looks like one, otherwise as a hint for documentation generation. Tested with both kaito-http/kaito repo and custom hints.