### PR TITLE
Feature/improve help command

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -22,6 +22,10 @@ export class AskCommand implements Command {
     this.config = loadConfig();
   }
 
+  getDescription(): string {
+    return 'Ask any model from any provider a direct question';
+  }
+
   async *execute(query: string, options?: CommandOptions): CommandGenerator {
     // Get available providers
     const availableProviders = getAvailableProviders().filter((p) => p.available);

--- a/src/commands/browser/browserCommand.ts
+++ b/src/commands/browser/browserCommand.ts
@@ -12,14 +12,71 @@ export class BrowserCommand implements Command {
     act: new ActCommand(),
     extract: new ExtractCommand(),
     observe: new ObserveCommand(),
+    help: {
+      execute: async function* (this: BrowserCommand, _: string, options: CommandOptions) {
+        yield this.getHelp();
+      }.bind(this),
+    },
   };
+
+  getDescription(): string {
+    return 'Automate browser actions and extract web content';
+  }
+
+  getHelp(): string {
+    return `Browser Command - Automate browser actions and extract web content
+
+Usage: cursor-tools browser <subcommand> [args] [options]
+
+Subcommands:
+  open <url>                Open URL and capture page content
+  act "<instruction>"       Execute actions on a webpage
+  observe "<instruction>"   Observe interactive elements
+  extract "<instruction>"   Extract data from a webpage
+  help                      Show this help message
+
+Common Options:
+  --url=<url>              URL to navigate to (required for act/observe/extract)
+  --console                Capture browser console logs (default: true)
+  --html                   Capture page HTML content
+  --network               Capture network activity (default: true)
+  --screenshot=<path>      Save a screenshot of the page
+  --timeout=<ms>          Set navigation timeout (default: 30000ms)
+  --viewport=<WxH>        Set viewport size (e.g., 1280x720)
+  --headless              Run browser in headless mode (default: true)
+  --no-headless          Show browser UI for debugging
+  --connect-to=<port>     Connect to existing Chrome instance
+  --video=<directory>     Save a video recording (1280x720)
+
+Examples:
+  cursor-tools browser open "https://example.com" --html
+  cursor-tools browser act "Click Login" --url=https://example.com
+  cursor-tools browser act "Click Login | Type 'user@example.com' into email | Click Submit" --url=https://example.com
+  cursor-tools browser observe "interactive elements" --url=https://example.com
+  cursor-tools browser extract "product names" --url=https://example.com/products
+  cursor-tools browser help                 # Show this help message
+
+Notes:
+- All commands are stateless unless using --connect-to
+- Special URL values with --connect-to:
+  - 'current': Use existing page without reload
+  - 'reload-current': Use existing page and refresh
+- Multi-step actions supported with pipe (|) separator
+- Video recording available for all commands
+- DO NOT use "wait" in act instructions
+
+Dependencies:
+- Requires Playwright: npm install -g playwright
+- Uses Stagehand for browser automation`;
+  }
 
   async *execute(query: string, options: CommandOptions): CommandGenerator {
     const [subcommand, ...rest] = query.split(' ');
     const subQuery = rest.join(' ');
 
-    if (!subcommand) {
-      yield 'Please specify a browser subcommand: open, element, act, extract, observe';
+    // If no subcommand provided or help requested, show help
+    if (!subcommand || subcommand === 'help' || options.help) {
+      yield* this.subcommands.help.execute('', options);
       return;
     }
 
@@ -28,7 +85,7 @@ export class BrowserCommand implements Command {
       if (subCommandHandler) {
         yield* subCommandHandler.execute(subQuery, options);
       } else {
-        yield `Unknown browser subcommand: ${subcommand}. Available subcommands: open, element, act, extract, observe`;
+        yield `Unknown browser subcommand: ${subcommand}. Available subcommands: open, element, act, extract, observe, help`;
       }
     } catch (error) {
       console.error('Error executing browser command', error);

--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -195,6 +195,10 @@ Please:
     throw new NetworkError('Failed to fetch GitHub repository context after all retries');
   }
 
+  getDescription(): string {
+    return 'Generate comprehensive documentation for this repository';
+  }
+
   async *execute(query: string, options: DocCommandOptions): CommandGenerator {
     try {
       console.error('Generating repository documentation...\n');

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -6,21 +6,57 @@ export class GithubCommand implements Command {
   private subcommands: CommandMap = {
     pr: new PrCommand(),
     issue: new IssueCommand(),
+    help: {
+      execute: async function* (this: GithubCommand, _: string, options: CommandOptions) {
+        yield this.getHelp();
+      }.bind(this),
+    },
   };
+
+  getDescription(): string {
+    return 'Get information about GitHub PRs and issues';
+  }
+
+  getHelp(): string {
+    return `GitHub Command - Get information about GitHub PRs and issues
+
+Usage: cursor-tools github <subcommand> [args] [options]
+
+Subcommands:
+  pr [number]     Get the last 10 PRs, or a specific PR by number
+  issue [number]  Get the last 10 issues, or a specific issue by number
+  help            Show this help message
+
+Options:
+  --from-github=<username>/<repository>[@<branch>]  Access PRs/issues from a specific GitHub repository
+
+Examples:
+  cursor-tools github pr                  # List last 10 PRs
+  cursor-tools github pr 123              # Get details of PR #123
+  cursor-tools github issue               # List last 10 issues
+  cursor-tools github issue 456           # Get details of issue #456
+  cursor-tools github help                # Show this help message
+
+Notes:
+- Defaults to the current repository if --from-github is not specified
+- Requires appropriate GitHub access permissions
+- Uses GitHub API rate limits`;
+  }
 
   async *execute(query: string, options: CommandOptions): CommandGenerator {
     const [subcommand, ...rest] = query.split(' ');
     const subQuery = rest.join(' ');
 
-    if (!subcommand) {
-      yield 'Please specify a subcommand: pr or issue';
+    // If no subcommand provided or help requested, show help
+    if (!subcommand || subcommand === 'help' || options.help) {
+      yield* this.subcommands.help.execute('', options);
       return;
     }
 
     if (this.subcommands[subcommand]) {
       yield* this.subcommands[subcommand].execute(subQuery, options);
     } else {
-      yield `Unknown subcommand: ${subcommand}. Available subcommands: pr, issue`;
+      yield `Unknown subcommand: ${subcommand}. Available subcommands: pr, issue, help`;
     }
   }
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -23,6 +23,10 @@ Examples:
 Available Commands:
 ${this.getCommandList()}
 
+For detailed help on a specific command, run:
+  cursor-tools help <command>
+  cursor-tools instructions     Get complete documentation and examples
+
 Notes:
 - Use --help flag with any command for quick help
 - Each command may have its own specific options
@@ -58,6 +62,10 @@ Notes:
 
   private getGeneralHelp(): string {
     return `cursor-tools - AI-powered CLI tool for development tasks
+
+Quick Start:
+  cursor-tools instructions     Get complete instructions and command reference
+  cursor-tools help <command>   Get detailed help for a specific command
 
 Usage: cursor-tools [options] <command> [args]
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,99 @@
+import { Command, CommandOptions, CommandGenerator } from '../types.ts';
+import { commands } from './index.ts';
+
+export class HelpCommand implements Command {
+  getDescription(): string {
+    return 'Show help information for commands';
+  }
+
+  getHelp(): string {
+    return `Help Command - Show help information for commands
+
+Usage: cursor-tools help [command]
+
+Arguments:
+  command   Optional command name to get detailed help for
+
+Examples:
+  cursor-tools help              # Show general help
+  cursor-tools help xcode        # Show help for xcode command
+  cursor-tools help browser      # Show help for browser command
+  cursor-tools help repo         # Show help for repo command
+
+Available Commands:
+${this.getCommandList()}
+
+Notes:
+- Use --help flag with any command for quick help
+- Each command may have its own specific options
+- See command-specific help for detailed usage
+- Visit GitHub repository for full documentation`;
+  }
+
+  async *execute(query: string, options: CommandOptions): CommandGenerator {
+    // If a specific command is provided, show help for that command
+    if (query) {
+      const command = commands[query];
+      if (!command) {
+        yield `Unknown command: ${query}\n`;
+        yield `Available commands: ${Object.keys(commands).join(', ')}\n`;
+        return;
+      }
+      
+      // Get help text from the command if it has a getHelp method
+      if ('getHelp' in command && typeof command.getHelp === 'function') {
+        yield command.getHelp();
+        return;
+      }
+      
+      // Fallback to basic help text
+      yield `Help for command: ${query}\n`;
+      yield `No detailed help available for this command.\n`;
+      return;
+    }
+
+    // Show general help text
+    yield this.getGeneralHelp();
+  }
+
+  private getGeneralHelp(): string {
+    return `cursor-tools - AI-powered CLI tool for development tasks
+
+Usage: cursor-tools [options] <command> [args]
+
+Global Options:
+  --model=<model>           Specify an alternative AI model to use
+  --max-tokens=<number>     Control response length
+  --save-to=<file path>    Save command output to a file
+  --from-github=<url>      Access GitHub repository content
+  --output=<filepath>      Specify output file path
+  --hint=<hint>            Provide additional context
+  --help                   Show this help message
+
+Available Commands:
+${this.getCommandList()}
+
+For detailed help on a specific command, run:
+  cursor-tools help <command>
+
+Examples:
+  cursor-tools web "latest weather in London"
+  cursor-tools repo "explain authentication flow"
+  cursor-tools doc --output docs.md
+  cursor-tools browser open "https://example.com" --html
+
+For more information, visit: https://github.com/eastlondoner/cursor-tools
+`;
+  }
+
+  private getCommandList(): string {
+    return Object.entries(commands)
+      .map(([name, command]) => {
+        const description = 'getDescription' in command && typeof command.getDescription === 'function'
+          ? command.getDescription()
+          : 'No description available';
+        return `  ${name.padEnd(15)} ${description}`;
+      })
+      .join('\n');
+  }
+} 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,6 +8,7 @@ import { RepoCommand } from './repo.ts';
 import { DocCommand } from './doc.ts';
 import { AskCommand } from './ask.ts';
 import { MCPCommand } from './mcp/mcp.ts';
+import { XcodeCommand } from './xcode/xcode.ts';
 
 export const commands: CommandMap = {
   web: new WebCommand(),
@@ -19,4 +20,5 @@ export const commands: CommandMap = {
   plan: new PlanCommand(),
   ask: new AskCommand(),
   mcp: new MCPCommand(),
+  xcode: new XcodeCommand(),
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,26 +1,28 @@
-import type { CommandMap } from '../types.ts';
-import { WebCommand } from './web.ts';
-import { InstallCommand } from './install.ts';
-import { GithubCommand } from './github.ts';
+import { Command } from '../types.ts';
+import { AskCommand } from './ask.ts';
 import { BrowserCommand } from './browser/browserCommand.ts';
+import { DocCommand } from './doc.ts';
+import { GithubCommand } from './github.ts';
+import { HelpCommand } from './help.ts';
+import { InstallCommand } from './install.ts';
+import { MCPCommand } from './mcp/mcp.ts';
 import { PlanCommand } from './plan.ts';
 import { RepoCommand } from './repo.ts';
-import { DocCommand } from './doc.ts';
-import { AskCommand } from './ask.ts';
-import { MCPCommand } from './mcp/mcp.ts';
+import { WebCommand } from './web.ts';
 import { XcodeCommand } from './xcode/xcode.ts';
-import { HelpCommand } from './help.ts';
+import { InstructionsCommand } from './instructions.ts';
 
-export const commands: CommandMap = {
-  web: new WebCommand(),
-  repo: new RepoCommand(),
-  install: new InstallCommand(),
+export const commands: Record<string, Command> = {
+  ask: new AskCommand(),
+  browser: new BrowserCommand(),
   doc: new DocCommand(),
   github: new GithubCommand(),
-  browser: new BrowserCommand(),
-  plan: new PlanCommand(),
-  ask: new AskCommand(),
-  mcp: new MCPCommand(),
-  xcode: new XcodeCommand(),
   help: new HelpCommand(),
+  install: new InstallCommand(),
+  mcp: new MCPCommand(),
+  plan: new PlanCommand(),
+  repo: new RepoCommand(),
+  web: new WebCommand(),
+  xcode: new XcodeCommand(),
+  instructions: new InstructionsCommand(),
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,7 @@ import { DocCommand } from './doc.ts';
 import { AskCommand } from './ask.ts';
 import { MCPCommand } from './mcp/mcp.ts';
 import { XcodeCommand } from './xcode/xcode.ts';
+import { HelpCommand } from './help.ts';
 
 export const commands: CommandMap = {
   web: new WebCommand(),
@@ -21,4 +22,5 @@ export const commands: CommandMap = {
   ask: new AskCommand(),
   mcp: new MCPCommand(),
   xcode: new XcodeCommand(),
+  help: new HelpCommand(),
 };

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -67,6 +67,10 @@ async function askForCursorRulesDirectory(): Promise<boolean> {
 }
 
 export class InstallCommand implements Command {
+  getDescription(): string {
+    return 'Install cursor-tools globally or locally';
+  }
+
   private async *setupApiKeys(): CommandGenerator {
     loadEnv(); // Load existing env files if any
 

--- a/src/commands/instructions.ts
+++ b/src/commands/instructions.ts
@@ -1,0 +1,37 @@
+import { Command, CommandOptions, CommandGenerator } from '../types.ts';
+import { CURSOR_RULES_TEMPLATE } from '../cursorrules.ts';
+
+export class InstructionsCommand implements Command {
+  async *execute(query?: string, options?: CommandOptions): CommandGenerator {
+    // Extract just the cursor-tools Integration section
+    const startTag = '<cursor-tools Integration>';
+    const endTag = '</cursor-tools Integration>';
+    const start = CURSOR_RULES_TEMPLATE.indexOf(startTag) + startTag.length;
+    const end = CURSOR_RULES_TEMPLATE.indexOf(endTag);
+    const instructions = CURSOR_RULES_TEMPLATE.slice(start, end).trim();
+    
+    yield instructions;
+  }
+
+  getDescription(): string {
+    return 'Output the cursor-tools instructions and command reference';
+  }
+
+  getHelp(): string {
+    return `
+Usage: cursor-tools instructions
+
+Output the complete cursor-tools instructions and command reference.
+This includes detailed information about all available commands, their options,
+and best practices for using cursor-tools effectively.
+
+Options:
+  --save-to=<file path>  Save the instructions to a file in addition to displaying them
+  --help                 Show this help message
+
+Examples:
+  cursor-tools instructions
+  cursor-tools instructions --save-to=cursor-tools-reference.md
+`;
+  }
+} 

--- a/src/commands/mcp/mcp.ts
+++ b/src/commands/mcp/mcp.ts
@@ -20,7 +20,47 @@ export class MCPCommand implements Command {
   private subcommands: CommandMap = {
     search: new SearchCommand(this.marketplaceManager),
     run: new RunCommand(this.marketplaceManager),
+    help: {
+      execute: async function* (this: MCPCommand, _: string, options: CommandOptions) {
+        yield this.getHelp();
+      }.bind(this),
+    },
   };
+
+  getDescription(): string {
+    return 'Execute specialized tools through MCP servers';
+  }
+
+  getHelp(): string {
+    return `MCP Command - Execute specialized tools through MCP servers
+
+Usage: cursor-tools mcp <subcommand> [args] [options]
+
+Subcommands:
+  run <tool>    Execute a specific MCP tool
+  search        Search available MCP tools
+  help          Show this help message
+
+Options:
+  --model=<model>         Model to use for tool execution
+  --max-tokens=<number>   Maximum tokens for response
+  --save-to=<file path>   Save output to a file
+
+Examples:
+  cursor-tools mcp run git-commit          # Run git commit tool
+  cursor-tools mcp search "git tools"      # Search for git-related tools
+  cursor-tools mcp help                    # Show this help message
+
+Notes:
+- Uses AI to determine appropriate tool arguments
+- Supports multiple MCP server implementations
+- Can connect to custom MCP servers
+- Handles environment variables and configuration
+
+Dependencies:
+- Requires appropriate API keys in .cursor-tools.env
+- Some tools may require additional dependencies`;
+  }
 
   async *execute(query: string, options: CommandOptions): CommandGenerator {
     try {
@@ -28,11 +68,17 @@ export class MCPCommand implements Command {
       const [subcommand = 'run', ...rest] = query.split(' ');
       const subQuery = rest.join(' ');
 
+      // If no subcommand provided or help requested, show help
+      if (!subcommand || subcommand === 'help' || options.help) {
+        yield* this.subcommands.help.execute('', options);
+        return;
+      }
+
       const subCommandHandler = this.subcommands[subcommand];
       if (subCommandHandler) {
         yield* subCommandHandler.execute(subQuery, options);
       } else {
-        yield `Unknown MCP subcommand: ${subcommand}. Available subcommands: search, run`;
+        yield `Unknown MCP subcommand: ${subcommand}. Available subcommands: search, run, help`;
       }
     } catch (error) {
       this.handleError(error, options?.debug);

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -42,6 +42,10 @@ export class PlanCommand implements Command {
     this.config = loadConfig();
   }
 
+  getDescription(): string {
+    return 'Generate a focused implementation plan using AI';
+  }
+
   async *execute(query: string, options: PlanCommandOptions): CommandGenerator {
     try {
       // Check for conflicting model options

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -25,6 +25,40 @@ export class RepoCommand implements Command {
     this.config = loadConfig();
   }
 
+  getDescription(): string {
+    return 'Get context-aware answers about this repository using Google Gemini';
+  }
+
+  getHelp(): string {
+    return `Repository Command - Get context-aware answers about this repository
+
+Usage: cursor-tools repo "<query>" [options]
+
+Options:
+  --provider=<provider>    AI provider to use (gemini, openai, openrouter, perplexity, or modelbox)
+  --model=<model>         Model to use for repository analysis
+  --max-tokens=<number>   Maximum tokens for response
+  --save-to=<file path>   Save output to a file (in addition to stdout)
+
+Examples:
+  cursor-tools repo "explain authentication flow"
+  cursor-tools repo "review recent changes to error handling"
+  cursor-tools repo "find security vulnerabilities in the codebase"
+  cursor-tools repo "suggest improvements to the API design"
+
+Notes:
+- Uses Google Gemini by default for repository analysis
+- Has a 2M token context window for large codebases
+- Context can be reduced using .repomixignore file
+- Provides code-aware responses with file references
+- Can analyze code patterns and suggest improvements
+- Ideal for code review and architecture discussions
+
+Dependencies:
+- Requires API key for chosen provider in .cursor-tools.env
+- Uses repomix for repository context management`;
+  }
+
   async *execute(query: string, options?: CommandOptions): CommandGenerator {
     try {
       yield 'Packing repository using Repomix...\n';

--- a/src/commands/web.ts
+++ b/src/commands/web.ts
@@ -20,6 +20,36 @@ export class WebCommand implements Command {
     this.config = loadConfig();
   }
 
+  getDescription(): string {
+    return 'Get answers from the web using Perplexity AI';
+  }
+
+  getHelp(): string {
+    return `Web Command - Get answers from the web using Perplexity AI
+
+Usage: cursor-tools web "<query>" [options]
+
+Options:
+  --provider=<provider>    AI provider to use (perplexity, gemini, modelbox, or openrouter)
+  --model=<model>         Model to use for web search (model name depends on provider)
+  --max-tokens=<number>   Maximum tokens for response
+  --save-to=<file path>   Save output to a file (in addition to stdout)
+
+Examples:
+  cursor-tools web "latest shadcn/ui installation instructions"
+  cursor-tools web "current weather in London" --provider perplexity
+  cursor-tools web "typescript best practices 2024" --save-to local-research/typescript.md
+
+Notes:
+- Uses Perplexity AI by default for web search
+- Supports multiple providers with web search capabilities
+- Can save complex research to files for later reference
+- Streams results in real-time for immediate feedback
+
+Dependencies:
+- Requires API key for chosen provider in .cursor-tools.env`;
+  }
+
   async *execute(query: string, options: CommandOptions): CommandGenerator {
     try {
       const provider = options?.provider || this.config.web?.provider || 'perplexity';

--- a/src/commands/xcode/build.ts
+++ b/src/commands/xcode/build.ts
@@ -1,0 +1,197 @@
+/**
+ * Implementation of the Xcode build command.
+ * This command handles building iOS apps and reporting build errors.
+ *
+ * Key features:
+ * - Automatic project/workspace detection
+ * - Build output streaming
+ * - Error parsing and reporting
+ */
+
+import type { Command, CommandGenerator, CommandOptions } from '../../types';
+import { spawn } from 'node:child_process';
+import { findXcodeProject, type XcodeBuildError } from './utils.js';
+
+export class BuildCommand implements Command {
+  /**
+   * Builds the Xcode project and streams output.
+   * Handles both project and workspace configurations.
+   *
+   * @param dir - Project directory
+   * @returns Promise resolving to build info and errors
+   */
+  private async getBuildOutput(
+    dir: string
+  ): Promise<{ output: string; errors: XcodeBuildError[] }> {
+    return new Promise((resolve, reject) => {
+      const project = findXcodeProject(dir);
+      if (!project) {
+        reject(new Error('No Xcode project or workspace found in the current directory'));
+        return;
+      }
+
+      // Build the project/workspace
+      const args = [
+        '-configuration',
+        'Debug',
+        '-sdk',
+        'iphonesimulator',
+        '-scheme',
+        project.name,
+        'CODE_SIGN_IDENTITY=-',
+        'CODE_SIGNING_REQUIRED=NO',
+        'CODE_SIGNING_ALLOWED=NO',
+      ];
+
+      if (project.type === 'workspace') {
+        args.unshift('-workspace', project.path);
+      } else {
+        args.unshift('-project', project.path);
+      }
+
+      console.log('Running:', 'xcodebuild', args.join(' '));
+      const xcodebuild = spawn('xcodebuild', args, { cwd: dir });
+      let output = '';
+      xcodebuild.stdout.on('data', (data) => {
+        const text = data.toString();
+        output += text;
+        // Stream all build output for better debugging
+        console.log(text.trim());
+      });
+      xcodebuild.stderr.on('data', (data) => {
+        const text = data.toString();
+        output += text;
+        console.error(text.trim());
+      });
+      xcodebuild.on('error', reject);
+      xcodebuild.on('close', (code) => {
+        if (code === 0) {
+          resolve({
+            output,
+            errors: this.parseBuildOutput(output),
+          });
+        } else {
+          reject(
+            new Error(
+              `Build failed with exit code ${code}. Check the build output above for details.`
+            )
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Parses build output to extract errors and warnings.
+   * Handles both file-specific and general messages.
+   *
+   * @param output - Raw build output string
+   * @returns Array of parsed errors
+   */
+  private parseBuildOutput(output: string): XcodeBuildError[] {
+    const errors: XcodeBuildError[] = [];
+    const lines = output.split('\n');
+
+    for (const line of lines) {
+      // Match lines with file paths (e.g. "/path/to/file: error: message")
+      if (line.includes(': error:') || line.includes(': warning:') || line.includes(': note:')) {
+        const match = line.match(/^(.+?):\s*(error|warning|note):\s*(.+)$/);
+        if (match) {
+          const [, file, type, message] = match;
+          errors.push({
+            file: file.trim(),
+            message: message.trim(),
+            type: type as 'error' | 'warning' | 'note',
+          });
+        }
+      }
+      // Match direct messages (e.g. "error: message")
+      else if (
+        line.trim().startsWith('error:') ||
+        line.trim().startsWith('warning:') ||
+        line.trim().startsWith('note:')
+      ) {
+        const match = line.trim().match(/^(error|warning|note):\s*(.+)$/);
+        if (match) {
+          const [, type, message] = match;
+          errors.push({
+            message: message.trim(),
+            type: type as 'error' | 'warning' | 'note',
+          });
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * Main execution method for the build command.
+   * Builds the project and reports any errors or warnings.
+   *
+   * @param query - Command query string (unused)
+   * @param options - Command options
+   * @yields Status messages and command output
+   */
+  async *execute(query: string, options: CommandOptions): CommandGenerator {
+    try {
+      const dir = process.cwd();
+      const project = findXcodeProject(dir);
+      if (!project) {
+        throw new Error('No Xcode project or workspace found in current directory');
+      }
+
+      yield 'Building Xcode project...\n';
+
+      const { errors } = await this.getBuildOutput(dir);
+
+      // Group errors by type
+      const buildErrors = errors.filter((e) => e.type === 'error');
+      const warnings = errors.filter((e) => e.type === 'warning');
+      const notes = errors.filter((e) => e.type === 'note');
+
+      // Report errors first - these are blocking
+      if (buildErrors.length > 0) {
+        yield '\nBuild Errors:\n';
+        for (const error of buildErrors) {
+          if (error.file) {
+            yield `${error.file}: ${error.message}\n`;
+          } else {
+            yield `${error.message}\n`;
+          }
+        }
+        throw new Error('Build failed due to errors');
+      }
+
+      // Report warnings - these are non-blocking
+      if (warnings.length > 0) {
+        yield '\nWarnings:\n';
+        for (const warning of warnings) {
+          if (warning.file) {
+            yield `${warning.file}: ${warning.message}\n`;
+          } else {
+            yield `${warning.message}\n`;
+          }
+        }
+        yield '\nUse "cursor-tools xcode lint" to analyze and fix warnings.\n';
+      }
+
+      // Report notes - these are informational
+      if (notes.length > 0) {
+        yield '\nNotes:\n';
+        for (const note of notes) {
+          if (note.file) {
+            yield `${note.file}: ${note.message}\n`;
+          } else {
+            yield `${note.message}\n`;
+          }
+        }
+      }
+
+      yield '\nBuild completed successfully.\n';
+    } catch (error: any) {
+      console.error(`Build failed: ${error}`);
+      throw error;
+    }
+  }
+}

--- a/src/commands/xcode/command.ts
+++ b/src/commands/xcode/command.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry point for the Xcode command functionality in cursor-tools.
+ * This file exports the main XcodeCommand instance that handles all Xcode-related operations.
+ *
+ * The command is designed to be simple and focused, delegating actual functionality
+ * to subcommands like 'build' for better organization and maintainability.
+ */
+
+import { XcodeCommand } from './xcode.js';
+
+// Export a singleton instance of XcodeCommand to be used by the CLI
+export default new XcodeCommand();

--- a/src/commands/xcode/lint.ts
+++ b/src/commands/xcode/lint.ts
@@ -1,0 +1,80 @@
+/**
+ * Implementation of the Xcode lint command.
+ * This command analyzes code and offers to fix warnings.
+ *
+ * Key features:
+ * - Warning analysis
+ * - Interactive fixes
+ * - SwiftLint integration
+ */
+
+import type { Command, CommandGenerator, CommandOptions } from '../../types';
+import { findXcodeProject } from './utils.js';
+import { BuildCommand } from './build.js';
+
+export class LintCommand implements Command {
+  /**
+   * Main execution method for the lint command.
+   * Analyzes code and offers to fix warnings.
+   *
+   * @param query - Command query string (unused)
+   * @param options - Command options
+   * @yields Status messages and command output
+   */
+  async *execute(query: string, options: CommandOptions): CommandGenerator {
+    try {
+      const dir = process.cwd();
+      const project = findXcodeProject(dir);
+      if (!project) {
+        throw new Error('No Xcode project or workspace found in current directory');
+      }
+
+      yield 'Building project to check for warnings...\n';
+
+      // First build the project to get warnings
+      const buildCommand = new BuildCommand();
+      let warnings: string[] = [];
+      try {
+        yield* buildCommand.execute('', options);
+      } catch (error: any) {
+        // Capture any build output that might contain warnings
+        if (error.message) {
+          warnings = error.message
+            .split('\n')
+            .filter((line: string) => line.includes(': warning:'))
+            .map((line: string) => line.trim());
+        }
+        if (error.message.includes('Build failed due to errors')) {
+          throw new Error(
+            'Cannot analyze warnings while there are build errors. Please fix errors first.'
+          );
+        }
+      }
+
+      if (warnings.length === 0) {
+        yield 'No warnings found!\n';
+        return;
+      }
+
+      yield `\nFound ${warnings.length} warnings to analyze:\n`;
+      for (const warning of warnings) {
+        yield `${warning}\n`;
+      }
+
+      yield '\nTo fix these warnings:\n';
+      yield '1. Use SwiftLint to enforce consistent style:\n';
+      yield '   brew install swiftlint\n';
+      yield '   Add .swiftlint.yml to your project\n';
+      yield '\n2. Common fixes:\n';
+      yield '   - Unused variables: Remove or use `_`\n';
+      yield '   - Long lines: Break into multiple lines\n';
+      yield '   - Force unwrap: Use optional binding\n';
+      yield '   - Implicit type: Explicitly declare types\n';
+      yield '\n3. Run SwiftLint auto-correct:\n';
+      yield '   swiftlint --fix\n';
+    } catch (error: any) {
+      console.error(`Lint failed: ${error}`);
+      throw error;
+    }
+  }
+}

--- a/src/commands/xcode/run.ts
+++ b/src/commands/xcode/run.ts
@@ -1,0 +1,274 @@
+/**
+ * Implementation of the Xcode run command.
+ * This command handles running iOS apps in the simulator.
+ *
+ * Key features:
+ * - Simulator device management
+ * - Device state detection
+ * - App installation and launch
+ */
+
+import type { Command, CommandGenerator, CommandOptions } from '../../types';
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execAsync } from '../../utils/execAsync.js';
+import { BuildCommand } from './build.js';
+import { DEVICE_TYPES, DEFAULT_TIMEOUTS } from './utils.js';
+
+/**
+ * Command-specific flags and options
+ */
+interface RunCommandFlags {
+  device?: string; // Target device for the build (iphone/ipad)
+}
+
+export class RunCommand implements Command {
+  flags: RunCommandFlags = {};
+
+  /**
+   * Ensures that the Simulator.app is running.
+   * This is required before we can interact with simulator devices.
+   * @param deviceId - The ID of the device we want to use
+   */
+  private async ensureSimulatorRunning(deviceId: string): Promise<void> {
+    try {
+      // Check if Simulator.app is running
+      const { stdout } = await execAsync('pgrep -x "Simulator"');
+      if (!stdout.trim()) {
+        console.log('Starting Simulator.app...');
+        // Start Simulator.app with the specific device
+        await execAsync(`xcrun simctl boot "${deviceId}" && open -a Simulator --args -CurrentDeviceUDID "${deviceId}"`);
+        // Wait longer for it to fully start
+        console.log('Waiting for Simulator.app to initialize...');
+        await new Promise((resolve) => setTimeout(resolve, DEFAULT_TIMEOUTS.SIMULATOR_BOOT));
+      } else {
+        // If Simulator is already running, ensure we're using the right device
+        await execAsync(`open -a Simulator --args -CurrentDeviceUDID "${deviceId}"`);
+      }
+    } catch (error: any) {
+      // Only throw if it's not already booted
+      if (!error.message?.includes('Unable to boot device in current state: Booted')) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Gets the UUID for a simulator device by name.
+   * Handles parsing the output of xcrun simctl list devices.
+   *
+   * @param deviceName - Name of the device to find
+   * @returns Promise resolving to the device UUID
+   * @throws Error if device not found or UUID can't be parsed
+   */
+  private async getDeviceId(deviceName: string): Promise<string> {
+    const deviceList = await this.getDeviceList();
+    console.log('Available devices:', deviceList);
+
+    const lines = deviceList.split('\n');
+    for (const line of lines) {
+      if (line.includes(deviceName)) {
+        const uuidMatch = line.match(/\(([\w-]{36})\)/);
+        if (uuidMatch && uuidMatch[1]) {
+          const deviceId = uuidMatch[1];
+          console.log(`Found device ID for ${deviceName}: ${deviceId}`);
+          return deviceId;
+        }
+      }
+    }
+    throw new Error(`Could not find device ID for ${deviceName}`);
+  }
+
+  /**
+   * Gets the current state of a simulator device.
+   * States can be: Booted, Shutdown, etc.
+   *
+   * @param deviceId - UUID of the device
+   * @returns Current state string
+   */
+  private async getDeviceState(deviceId: string): Promise<string> {
+    const { stdout } = await execAsync(`xcrun simctl list devices | grep "${deviceId}"`);
+    // The state is in the last set of parentheses
+    const matches = stdout.match(/\(([\w-]+)\)/g);
+    if (matches && matches.length >= 2) {
+      // The last match contains the state
+      const state = matches[matches.length - 1].slice(1, -1);
+      console.log(`Current device state: ${state}`);
+      return state;
+    }
+    return 'Unknown';
+  }
+
+  /**
+   * Finds the built app bundle in DerivedData.
+   * Uses multiple strategies to ensure we find the correct bundle.
+   *
+   * @param projectDir - Project directory
+   * @returns Path to the .app bundle
+   */
+  private async findAppBundle(projectDir: string): Promise<string> {
+    try {
+      // First try to get the exact DerivedData path from build settings
+      const { stdout: buildSettingsOutput } = await execAsync('xcodebuild -showBuildSettings');
+      const lines = buildSettingsOutput.split('\n');
+
+      // Look for CONFIGURATION_BUILD_DIR first as it's most specific
+      let appPath = '';
+      for (const line of lines) {
+        if (line.includes('CONFIGURATION_BUILD_DIR =')) {
+          const buildDir = line.split('=')[1].trim();
+          const possiblePath = join(buildDir, 'PapersApp.app');
+          if (existsSync(possiblePath)) {
+            console.log(`Found app bundle at ${possiblePath}`);
+            return possiblePath;
+          }
+        }
+      }
+
+      // If not found, try TARGET_BUILD_DIR
+      for (const line of lines) {
+        if (line.includes('TARGET_BUILD_DIR =')) {
+          const buildDir = line.split('=')[1].trim();
+          const possiblePath = join(buildDir, 'PapersApp.app');
+          if (existsSync(possiblePath)) {
+            console.log(`Found app bundle at ${possiblePath}`);
+            return possiblePath;
+          }
+        }
+      }
+
+      // If still not found, search in DerivedData
+      const { stdout: derivedDataPath } = await execAsync(
+        'xcodebuild -showBuildSettings | grep OBJROOT'
+      );
+      const basePath = derivedDataPath.split('=')[1].trim().split('Build/Intermediates.noindex')[0];
+
+      // Search for .app bundles in the Debug-iphonesimulator directory
+      const searchPath = join(basePath, 'Build/Products/Debug-iphonesimulator');
+      if (existsSync(searchPath)) {
+        const files = readdirSync(searchPath);
+        const appBundle = files.find((f) => f.endsWith('.app'));
+        if (appBundle) {
+          appPath = join(searchPath, appBundle);
+          console.log(`Found app bundle at ${appPath}`);
+          return appPath;
+        }
+      }
+
+      throw new Error('Could not find built app bundle in DerivedData');
+    } catch (error: any) {
+      throw new Error(`Failed to find app bundle: ${error.message}`);
+    }
+  }
+
+  /**
+   * Handles the simulator lifecycle:
+   * 1. Gets device UUID
+   * 2. Checks device state
+   * 3. Boots simulator if needed
+   * 4. Installs and launches the app
+   *
+   * @param deviceName - Name of the simulator device
+   * @param bundleId - Bundle identifier of the app
+   * @param appPath - Path to the built .app bundle
+   */
+  private async runOnSimulator(deviceName: string, bundleId: string, appPath: string) {
+    // Get device ID from name
+    const deviceId = await this.getDeviceId(deviceName);
+
+    // First ensure Simulator.app is running with our desired device
+    await this.ensureSimulatorRunning(deviceId);
+
+    // Get current state
+    const state = await this.getDeviceState(deviceId);
+    console.log(`Current device state: ${state}`);
+
+    // Boot simulator if needed
+    if (state !== 'Booted') {
+      console.log('Booting simulator...');
+      try {
+        await execAsync(`xcrun simctl boot "${deviceId}"`);
+        // Wait for simulator to fully boot
+        console.log('Waiting for simulator to complete boot...');
+        await new Promise((resolve) => setTimeout(resolve, DEFAULT_TIMEOUTS.APP_LAUNCH));
+      } catch (error: any) {
+        if (!error.message?.includes('Unable to boot device in current state: Booted')) {
+          throw new Error(`Failed to boot simulator: ${error}`);
+        }
+      }
+    }
+
+    // Verify app path exists
+    if (!existsSync(appPath)) {
+      throw new Error(`App bundle not found at path: ${appPath}`);
+    }
+
+    // Install and launch app
+    console.log('Installing app...');
+    try {
+      await execAsync(`xcrun simctl install "${deviceId}" "${appPath}"`);
+    } catch (error: any) {
+      throw new Error(`Failed to install app: ${error.message}`);
+    }
+
+    console.log('Launching app...');
+    try {
+      await execAsync(`xcrun simctl launch "${deviceId}" "${bundleId}"`);
+    } catch (error: any) {
+      throw new Error(`Failed to launch app: ${error.message}`);
+    }
+
+    // Bring Simulator window to front
+    await execAsync('open -a Simulator');
+  }
+
+  /**
+   * Main execution method for the run command.
+   * First builds the app, then runs it in the simulator.
+   *
+   * @param query - Command query string (e.g., "iphone" or "ipad")
+   * @param options - Command options
+   * @yields Status messages and command output
+   */
+  async *execute(query: string, options: CommandOptions): CommandGenerator {
+    try {
+      // First build the project
+      const buildCommand = new BuildCommand();
+      yield* buildCommand.execute('', options);
+
+      // Get device type from query or use default
+      const deviceType = query.toLowerCase();
+      if (deviceType && !['iphone', 'ipad'].includes(deviceType)) {
+        throw new Error('Invalid device type. Use "iphone" or "ipad"');
+      }
+
+      // Get device name based on type
+      const deviceName = deviceType === 'ipad' 
+        ? DEVICE_TYPES.ipad 
+        : DEVICE_TYPES.iphone;
+
+      console.log(`Using device: ${deviceName}`);
+
+      // Find the app bundle using our improved method
+      const appPath = await this.findAppBundle(process.cwd());
+      console.log(`App path: ${appPath}`);
+
+      // Use the bundle identifier from your Xcode settings
+      const bundleId = 'com.papers.app';
+      console.log(`Using bundle identifier: ${bundleId}`);
+
+      // Run on simulator
+      await this.runOnSimulator(deviceName, bundleId, appPath);
+
+      yield 'App launched successfully in simulator.\n';
+    } catch (error: any) {
+      console.error(`Run failed: ${error}`);
+      throw error;
+    }
+  }
+
+  private async getDeviceList(): Promise<string> {
+    const { stdout } = await execAsync('xcrun simctl list devices');
+    return stdout;
+  }
+}

--- a/src/commands/xcode/utils.ts
+++ b/src/commands/xcode/utils.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared utilities for Xcode commands.
+ * Contains common functionality used across different Xcode command implementations.
+ */
+
+import { readdirSync } from 'node:fs';
+
+/**
+ * Information about an Xcode project
+ */
+export interface XcodeProject {
+  path: string;
+  type: 'project' | 'workspace';
+  name: string;
+}
+
+/**
+ * Represents a build error or warning from Xcode
+ */
+export interface XcodeBuildError {
+  file?: string; // Source file where the error occurred
+  line?: number; // Line number in the file
+  column?: number; // Column number in the file
+  message: string; // Error message
+  type: 'error' | 'warning' | 'note'; // Severity of the issue
+}
+
+/**
+ * Maps device types to their simulator names.
+ * These are the latest device types available in Xcode 15.
+ */
+export const DEVICE_TYPES = {
+  iphone: 'iPhone 15 Pro Max',
+  ipad: 'iPad Pro 13-inch (M4)',
+} as const;
+
+/**
+ * Default timeouts for various operations
+ */
+export const DEFAULT_TIMEOUTS = {
+  SIMULATOR_BOOT: 5000,
+  APP_LAUNCH: 3000,
+};
+
+/**
+ * Finds an Xcode project or workspace in the given directory.
+ * Prefers workspaces over projects as they're more common in modern apps.
+ *
+ * @param dir - Directory to search in
+ * @returns Project info or null if none found
+ */
+export function findXcodeProject(dir: string): XcodeProject | null {
+  const files = readdirSync(dir);
+
+  // First check for workspace since that's more common in modern projects
+  const workspace = files.find((f) => f.endsWith('.xcworkspace'));
+  if (workspace) {
+    return {
+      path: workspace,
+      type: 'workspace',
+      name: workspace.replace('.xcworkspace', ''),
+    };
+  }
+
+  // Then check for project
+  const project = files.find((f) => f.endsWith('.xcodeproj'));
+  if (project) {
+    return {
+      path: project,
+      type: 'project',
+      name: project.replace('.xcodeproj', ''),
+    };
+  }
+
+  return null;
+} 

--- a/src/commands/xcode/xcode.ts
+++ b/src/commands/xcode/xcode.ts
@@ -1,0 +1,79 @@
+/**
+ * Main orchestrator for Xcode-related commands in cursor-tools.
+ * Implements the Command interface and manages subcommands for different Xcode operations.
+ *
+ * Currently supported subcommands:
+ * - build: Builds the Xcode project and reports errors
+ * - lint: Analyzes code and offers to fix warnings
+ * - run: Builds and runs the app in simulator
+ *
+ * The command uses a subcommand pattern to keep the codebase organized and extensible.
+ * Each subcommand is implemented as a separate class that handles its specific functionality.
+ */
+
+import type { Command, CommandGenerator, CommandOptions } from '../../types';
+import { BuildCommand } from './build.js';
+import { RunCommand } from './run.js';
+import { LintCommand } from './lint.js';
+
+/**
+ * Maps subcommand names to their implementing classes.
+ * This allows easy addition of new subcommands without modifying existing code.
+ */
+type SubcommandMap = {
+  [key: string]: Command;
+};
+
+export class XcodeCommand implements Command {
+  /**
+   * Registry of available subcommands.
+   * Each subcommand is instantiated once and reused for all invocations.
+   */
+  private subcommands: SubcommandMap = {
+    build: new BuildCommand(),
+    run: new RunCommand(),
+    lint: new LintCommand(),
+  };
+
+  /**
+   * Main execution method for the Xcode command.
+   * Parses the input query to determine which subcommand to run.
+   *
+   * @param query - The command query string (e.g., "build" or "run iphone")
+   * @param options - Global command options that apply to all subcommands
+   * @yields Status messages and command output
+   */
+  async *execute(query: string, options: CommandOptions): CommandGenerator {
+    // Split query into subcommand and remaining args
+    const [subcommand, ...args] = query.split(' ');
+
+    // If no subcommand provided, show help
+    if (!subcommand) {
+      yield 'Usage: cursor-tools xcode <subcommand> [args]\n';
+      yield 'Available subcommands:';
+      yield '  build         Build Xcode project and report errors';
+      yield '  lint          Analyze code and offer to fix warnings';
+      yield '  run <device>  Build and run on simulator (iphone/ipad)\n';
+      yield 'Examples:';
+      yield '  cursor-tools xcode build';
+      yield '  cursor-tools xcode lint';
+      yield '  cursor-tools xcode run iphone';
+      yield '  cursor-tools xcode run ipad';
+      return;
+    }
+
+    // Get the subcommand handler
+    const handler = this.subcommands[subcommand];
+    if (!handler) {
+      yield `Unknown subcommand: ${subcommand}\n`;
+      yield 'Available subcommands:';
+      yield '  build         Build Xcode project and report errors';
+      yield '  lint          Analyze code and offer to fix warnings';
+      yield '  run <device>  Build and run on simulator (iphone/ipad)';
+      return;
+    }
+
+    // Execute the subcommand with remaining args
+    yield* handler.execute(args.join(' '), options);
+  }
+}

--- a/src/commands/xcode/xcode.ts
+++ b/src/commands/xcode/xcode.ts
@@ -12,9 +12,9 @@
  */
 
 import type { Command, CommandGenerator, CommandOptions } from '../../types';
-import { BuildCommand } from './build.js';
-import { RunCommand } from './run.js';
-import { LintCommand } from './lint.js';
+import { BuildCommand } from './build';
+import { RunCommand } from './run';
+import { LintCommand } from './lint';
 
 /**
  * Maps subcommand names to their implementing classes.
@@ -33,7 +33,56 @@ export class XcodeCommand implements Command {
     build: new BuildCommand(),
     run: new RunCommand(),
     lint: new LintCommand(),
+    help: {
+      execute: async function* (this: XcodeCommand, _: string, options: CommandOptions): CommandGenerator {
+        yield this.getHelp();
+      }.bind(this),
+    },
   };
+
+  /**
+   * Returns a description of the Xcode command for help text.
+   */
+  getDescription(): string {
+    return 'Build, run, and lint iOS apps in Xcode projects';
+  }
+
+  /**
+   * Returns detailed help text for the Xcode command.
+   */
+  getHelp(): string {
+    return `Xcode Command - Build, run, and lint iOS apps
+
+Usage: cursor-tools xcode <subcommand> [args]
+
+Subcommands:
+  build         Build Xcode project and report errors
+  run [device]  Build and run on simulator (iphone/ipad)
+  lint          Analyze code and offer to fix warnings
+  help          Show this help message
+
+Examples:
+  cursor-tools xcode build                # Build the project
+  cursor-tools xcode run iphone           # Run on iPhone simulator
+  cursor-tools xcode run ipad             # Run on iPad simulator
+  cursor-tools xcode lint                 # Analyze code for warnings
+  cursor-tools xcode help                 # Show this help message
+
+Notes:
+- Automatically detects .xcworkspace or .xcodeproj in current directory
+- Uses latest simulator devices (iPhone 15 Pro Max, iPad Pro 13-inch)
+- Streams build progress in real-time
+- Reports errors, warnings, and notes with file locations
+- Uses Debug configuration and iphonesimulator SDK
+- Automatically handles simulator lifecycle (boot, install, launch)
+- Detects app bundle identifier from Info.plist
+- Uses Xcode's DerivedData for build products
+- Includes SwiftLint integration for code style analysis
+
+Dependencies:
+- Requires Xcode and Xcode Command Line Tools
+- Optional: SwiftLint for enhanced code analysis`;
+  }
 
   /**
    * Main execution method for the Xcode command.
@@ -47,18 +96,9 @@ export class XcodeCommand implements Command {
     // Split query into subcommand and remaining args
     const [subcommand, ...args] = query.split(' ');
 
-    // If no subcommand provided, show help
-    if (!subcommand) {
-      yield 'Usage: cursor-tools xcode <subcommand> [args]\n';
-      yield 'Available subcommands:';
-      yield '  build         Build Xcode project and report errors';
-      yield '  lint          Analyze code and offer to fix warnings';
-      yield '  run <device>  Build and run on simulator (iphone/ipad)\n';
-      yield 'Examples:';
-      yield '  cursor-tools xcode build';
-      yield '  cursor-tools xcode lint';
-      yield '  cursor-tools xcode run iphone';
-      yield '  cursor-tools xcode run ipad';
+    // If no subcommand provided or help requested, show help
+    if (!subcommand || subcommand === 'help' || options.help) {
+      yield* this.subcommands.help.execute('', options);
       return;
     }
 
@@ -70,6 +110,7 @@ export class XcodeCommand implements Command {
       yield '  build         Build Xcode project and report errors';
       yield '  lint          Analyze code and offer to fix warnings';
       yield '  run <device>  Build and run on simulator (iphone/ipad)';
+      yield '  help          Show this help message';
       return;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface CommandOptions {
   debug: boolean;
   url?: string;
   json?: boolean; // Output results as JSON
+  help?: boolean; // Show help message
 
   // Output options
   saveTo?: string; // Path to save output to in addition to stdout
@@ -28,6 +29,8 @@ export interface CommandOptions {
 
 export interface Command {
   execute(query: string, options: CommandOptions): CommandGenerator;
+  getDescription?(): string;
+  getHelp?(): string;
 }
 
 export interface CommandMap {

--- a/src/utils/execAsync.ts
+++ b/src/utils/execAsync.ts
@@ -1,0 +1,20 @@
+/**
+ * Utility module that provides a Promise-based wrapper around Node's exec function.
+ * This allows for easier async/await usage of child process execution throughout the codebase.
+ *
+ * Usage:
+ * ```typescript
+ * try {
+ *   const { stdout, stderr } = await execAsync('some command');
+ *   console.log('Output:', stdout);
+ * } catch (error) {
+ *   console.error('Failed:', error);
+ * }
+ * ```
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+// Convert the callback-based exec function to a Promise-based one
+export const execAsync = promisify(exec);


### PR DESCRIPTION
# Add instructions command for easy access to cursor-tools documentation

Resolves #26

## Overview
This PR adds a new `instructions` command that outputs the complete cursor-tools documentation and command reference. The command is prominently featured in the help output to make it easy for AI agents to discover and use.

## Changes
- Add new `instructions` command that outputs the cursor-tools documentation
- Update help text to prominently feature the instructions command in "Quick Start" section
- Make instructions command discoverable via `cursor-tools --help`
- Register help command properly to ensure consistent help system

## Example Usage
```bash
# Get complete documentation and command reference
cursor-tools instructions

# Save documentation to a file
cursor-tools instructions --save-to=cursor-tools-docs.md
```

## Testing
- [x] `cursor-tools --help` shows instructions command prominently
- [x] `cursor-tools instructions` outputs complete documentation
- [x] `cursor-tools help instructions` shows command-specific help
- [x] Help system works correctly for all commands
