### PR TITLE
Add review-diff - command to review current diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **New `review-diff` command**: Review code changes with full repository context and git diff
+  - Combines repository snapshot with git diff for comprehensive code reviews
+  - Supports `--base=<branch>` to specify base branch (default: main)  
+  - Inherits options from `repo` command: `--subdir`, `--with-doc`, `--provider`, `--model`
+  - Ideal for reviewing pull requests and understanding change impact
+
 ## [0.61.5] - 2025-05-23
 
 ### Improved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,9 @@ when using web for complex queries suggest writing the output to a file somewher
 **Repository Context:**
 `vibe-tools repo "<your question>" [--subdir=<path>] [--from-github=<username/repo>] [--with-doc=<doc_url>]` - Get context-aware answers about this repository using Google Gemini (e.g., `vibe-tools repo "explain authentication flow"`). Use the optional `--subdir` parameter to analyze a specific subdirectory instead of the entire repository (e.g., `vibe-tools repo "explain the code structure" --subdir=src/components`). Use the optional `--from-github` parameter to analyze a remote GitHub repository without cloning it locally (e.g., `vibe-tools repo "explain the authentication system" --from-github=username/repo-name`). Use the optional `--with-doc` parameter to include content from a URL as additional context (e.g., `vibe-tools repo "implement feature X following the design spec" --with-doc=https://example.com/design-spec`).
 
+**Code Review with Diff:**
+`vibe-tools review-diff "<your review question>" [--base=<branch>] [--subdir=<path>] [--with-doc=<doc_url>]` - Review code changes by providing both repository context and git diff against a base branch (e.g., `vibe-tools review-diff "Review my authentication changes for security issues"`). Use the optional `--base` parameter to specify a different base branch (default: main) (e.g., `vibe-tools review-diff "What are the breaking changes?" --base=release-v2`). Supports the same options as repo command for subdirectory analysis and document context.
+
 **Documentation Generation:**
 `vibe-tools doc [options] [--with-doc=<doc_url>]` - Generate comprehensive documentation for this repository (e.g., `vibe-tools doc --output docs.md`). Can incorporate document context from a URL (e.g., `vibe-tools doc --with-doc=https://example.com/existing-docs`).
 
@@ -151,6 +154,7 @@ The `search` command helps you discover servers in the MCP Marketplace based on 
 **Tool Recommendations:**
 - `vibe-tools web` is best for general web information not specific to the repository. Generally call this without additional arguments.
 - `vibe-tools repo` is ideal for repository-specific questions, planning, code review and debugging. E.g. `vibe-tools repo "Review recent changes to command error handling looking for mistakes, omissions and improvements"`. Generally call this without additional arguments.
+- `vibe-tools review-diff` is ideal for reviewing code changes with full context. Use when you need to review what has changed against a base branch. E.g. `vibe-tools review-diff "Review my changes for potential bugs"` or `vibe-tools review-diff "Are there any breaking changes?" --base=develop`.
 - `vibe-tools plan` is ideal for planning tasks. E.g. `vibe-tools plan "Adding authentication with social login using Google and Github"`. Generally call this without additional arguments.
 - `vibe-tools doc` generates documentation for local or remote repositories.
 - `vibe-tools youtube` analyzes YouTube videos to generate summaries, transcripts, implementation plans, or custom analyses

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Use Cursor Composer in agent mode with command execution (not sure what this mea
 - `vibe-tools ask` allows direct querying of any model from any provider. It's best for simple questions where you want to use a specific model or compare responses from different models.
 - `vibe-tools web` uses an AI teammate with web search capability to answer questions. `web` is best for finding up-to-date information from the web that is not specific to the repository such as how to use a library to search for known issues and error messages or to get suggestions on how to do something. Web is a teammate who knows tons of stuff and is always up to date.
 - `vibe-tools repo` uses an AI teammate with large context window capability to answer questions. `repo` sends the entire repo as context so it is ideal for questions about how things work or where to find something, it is also great for code review, debugging and planning. is a teammate who knows the entire codebase inside out and understands how everything works together.
+- `vibe-tools review-diff` uses an AI teammate with code review capability to analyze changes. `review-diff` sends both the entire repo context AND a git diff against a base branch (default: main) to provide comprehensive code reviews. It's ideal for reviewing pull requests, understanding what changed, and getting feedback on your modifications. Review-diff is a teammate who can see both the big picture and the specific changes you've made.
 - `vibe-tools plan` uses an AI teammate with reasoning capability to plan complex tasks. Plan uses a two step process. First it does a whole repo search with a large context window model to find relevant files. Then it sends only those files as context to a thinking model to generate a plan it is great for planning complex tasks and for debugging and refactoring. Plan is a teammate who is really smart on a well defined problem, although doesn't consider the bigger picture.
 - `vibe-tools doc` uses an AI teammate with large context window capability to generate documentation for local or github hosted repositories by sending the entire repo as context. `doc` can be given precise documentation tasks or can be asked to generate complete docs from scratch it is great for generating docs updates or for generating local documentation for a libary or API that you use! Doc is a teammate who is great at summarising and explaining code, in this repo or in any other repo!
 - `vibe-tools browser` uses an AI teammate with browser control (aka operator) capability to operate web browsers. `browser` can operate in a hidden (headless) mode to invisibly test and debug web apps or it can be used to connect to an existing browser session to interactively share your browser with Cursor agent it is great for testing and debugging web apps and for carrying out any task that can be done in a browser such as reading information from a bug ticket or even filling out a form. Browser is a teammate who can help you test and debug web apps, and can share control of your browser to perform small browser-based tasks.
@@ -273,6 +274,16 @@ Note: in most cases you can say "ask Perplexity" instead of "use vibe-tools web"
 "Use vibe-tools repo to explain this React component with documentation from the official React docs. Use --with-doc=https://react.dev/reference/react/useState"
 
 Note: in most cases you can say "ask Gemini" instead of "use vibe-tools repo" and it will work the same.
+
+### Use review-diff for code reviews
+
+"Use vibe-tools review-diff to review my changes and suggest improvements"
+
+"Use vibe-tools review-diff to check if my authentication changes have any security issues. Use --base=develop if comparing against develop branch"
+
+"Use vibe-tools review-diff 'Are there any breaking changes in this PR?' --base=release-v2"
+
+Note: review-diff combines the full repository context with a git diff, making it ideal for comprehensive code reviews.
 
 ### Use doc generation
 
@@ -1114,6 +1125,25 @@ vibe-tools repo "Analyze the security implications of our authentication impleme
 
 # Include web documentation as context
 vibe-tools repo "Help me implement useState in my component" --with-doc=https://react.dev/reference/react/useState
+```
+
+#### Code Review Examples
+
+```bash
+# Review current changes
+vibe-tools review-diff "Review my changes and suggest improvements"
+
+# Security-focused review
+vibe-tools review-diff "Are there any security issues in these changes?"
+
+# Review against specific branch
+vibe-tools review-diff "What breaking changes exist?" --base=release-v2
+
+# Review with specific focus
+vibe-tools review-diff "Review the error handling in my changes" --base=develop
+
+# Save review to file
+vibe-tools review-diff "Provide a detailed code review" --save-to=code-review.md
 ```
 
 #### Direct Model Query Examples

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ import { GithubCommand } from './github.ts';
 import { BrowserCommand } from './browser/browserCommand.ts';
 import { PlanCommand } from './plan.ts';
 import { RepoCommand } from './repo.ts';
+import { ReviewDiffCommand } from './review-diff.ts';
 import { DocCommand } from './doc.ts';
 import { AskCommand } from './ask.ts';
 import { MCPCommand } from './mcp/mcp.ts';
@@ -18,6 +19,7 @@ import { WaitCommand } from './wait.ts';
 export const commands: CommandMap = {
   web: new WebCommand(),
   repo: new RepoCommand(),
+  'review-diff': new ReviewDiffCommand(),
   install: new InstallCommand(),
   doc: new DocCommand(),
   github: new GithubCommand(),

--- a/src/commands/review-diff.ts
+++ b/src/commands/review-diff.ts
@@ -1,0 +1,345 @@
+import type { Command, CommandGenerator, CommandOptions, Provider } from '../types';
+import type { Config } from '../types';
+import type { AsyncReturnType } from '../utils/AsyncReturnType';
+import type { ModelOptions } from '../providers/base';
+
+import { defaultMaxTokens, loadConfig, loadEnv } from '../config';
+import { pack } from 'repomix';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { FileError, ProviderError } from '../errors';
+import type { BaseModelProvider } from '../providers/base';
+import { createProvider } from '../providers/base';
+import { loadFileConfigWithOverrides } from '../repomix/repomixConfig';
+import {
+  getNextAvailableProvider,
+  getDefaultModel,
+  getProviderInfo,
+  getAvailableProviders,
+  isProviderAvailable,
+} from '../utils/providerAvailability';
+import { fetchDocContent } from '../utils/fetch-doc';
+import { execAsync } from '../utils/execAsync';
+
+export class ReviewDiffCommand implements Command {
+  private config: Config;
+
+  constructor() {
+    loadEnv();
+    this.config = loadConfig();
+  }
+
+  async *execute(query: string, options: CommandOptions): CommandGenerator {
+    try {
+      const baseBranch = options.base || 'main';
+
+      // Determine the directory to analyze
+      const targetDirectory = options.subdir
+        ? resolve(process.cwd(), options.subdir)
+        : process.cwd();
+
+      // Validate that the target directory exists
+      if (options.subdir && !existsSync(targetDirectory)) {
+        throw new FileError(`The directory "${targetDirectory}" does not exist.`);
+      }
+
+      if (options.subdir) {
+        yield `Analyzing subdirectory: ${options.subdir}\n`;
+      }
+
+      yield 'Packing repository using Repomix...\n';
+
+      // Get repository snapshot
+      const repoContext = await this.getRepoSnapshot(targetDirectory);
+      if (repoContext.warning) {
+        yield repoContext.warning + '\n';
+      }
+
+      // Get git diff
+      yield `Computing changes from ${baseBranch}...\n`;
+      const gitDiffResult = await this.getGitDiff(baseBranch);
+      if (gitDiffResult.warning) {
+        yield gitDiffResult.warning + '\n';
+      }
+      const diffContent = gitDiffResult.diff;
+
+      // Fetch document content if the flag is provided
+      let docContent = '';
+      if (options?.withDoc && Array.isArray(options.withDoc) && options.withDoc.length > 0) {
+        const docContents: string[] = [];
+        yield `Fetching and extracting text from ${options.withDoc.length} document(s)...\n`;
+
+        for (const docUrl of options.withDoc) {
+          if (typeof docUrl !== 'string' || !docUrl.trim()) {
+            yield `Warning: Invalid URL provided in --with-doc: "${docUrl}". Skipping.\n`;
+            continue;
+          }
+
+          try {
+            yield `Fetching from: ${docUrl}...\n`;
+            const cleanedText = await fetchDocContent(docUrl, options.debug ?? false);
+
+            if (cleanedText && cleanedText.trim().length > 0) {
+              docContents.push(cleanedText);
+              yield `Successfully extracted content from: ${docUrl}\n`;
+            } else {
+              yield `Warning: fetchDocContent returned empty or whitespace-only text for ${docUrl}. Skipping.\n`;
+            }
+          } catch (fetchExtractError) {
+            const errorMessage =
+              fetchExtractError instanceof Error
+                ? fetchExtractError.message
+                : String(fetchExtractError);
+            yield `Error during document fetch/extraction for ${docUrl}: ${errorMessage}. Skipping this document.\n`;
+          }
+        }
+
+        if (docContents.length > 0) {
+          docContent = docContents.join('\n\n---\n\n'); // Separator between documents
+          yield `Successfully added content from ${docContents.length} document(s) to the context.\n`;
+        } else {
+          yield `Warning: No content successfully extracted from any provided --with-doc URLs. Proceeding without document context.\n`;
+        }
+      } else if (options?.withDoc) {
+        yield `Warning: --with-doc provided but not in the expected format (array of URLs). Proceeding without document context.\n`;
+      }
+
+      // Format the combined output
+      const formattedContent = this.formatOutput(repoContext, diffContent, query, baseBranch);
+
+      // Count tokens if needed
+      const tokenCount = repoContext.tokenCount;
+      if (tokenCount > 200_000) {
+        options.tokenCount = tokenCount;
+      }
+
+      // Track telemetry for context size
+      if (options?.trackTelemetry) {
+        // Rough token estimation (4 chars per token)
+        const diffTokenEstimate = Math.floor((diffContent?.length || 0) / 4);
+        const docTokenEstimate = Math.floor((docContent?.length || 0) / 4);
+        const totalContextTokens = tokenCount + diffTokenEstimate + docTokenEstimate;
+        options.trackTelemetry({ contextTokens: totalContextTokens });
+      }
+
+      // Get provider and execute
+      const providerName = options?.provider || this.config.repo?.provider || 'gemini';
+      const availableProvidersList = getAvailableProviders()
+        .map((p) => p.provider)
+        .join(', ');
+
+      if (!getProviderInfo(providerName)) {
+        throw new ProviderError(
+          `Unrecognized provider: ${providerName}.`,
+          `Try one of ${availableProvidersList}`
+        );
+      }
+
+      // If provider is explicitly specified, try only that provider
+      if (options?.provider) {
+        if (!isProviderAvailable(options.provider)) {
+          throw new ProviderError(
+            `Provider ${options.provider} is not available. Please check your API key configuration.`,
+            `Try one of ${availableProvidersList}`
+          );
+        }
+        yield* this.tryProvider(
+          options.provider as Provider,
+          formattedContent,
+          options,
+          docContent
+        );
+        return;
+      }
+
+      let currentProvider = null;
+
+      const noAvailableProvidersMsg =
+        'No suitable AI provider available for review-diff command. Please ensure at least one of the following API keys are set in your ~/.vibe-tools/.env file: GEMINI_API_KEY, OPENAI_API_KEY, OPENROUTER_API_KEY, PERPLEXITY_API_KEY, MODELBOX_API_KEY.';
+
+      if (this.config.repo?.provider && isProviderAvailable(this.config.repo?.provider)) {
+        currentProvider = this.config.repo.provider;
+      }
+
+      if (!currentProvider) {
+        currentProvider = getNextAvailableProvider('repo');
+      }
+
+      if (!currentProvider) {
+        throw new ProviderError(noAvailableProvidersMsg);
+      }
+
+      while (currentProvider) {
+        try {
+          yield* this.tryProvider(currentProvider, formattedContent, options, docContent);
+          return; // If successful, we're done
+        } catch (error) {
+          console.error(
+            `Provider ${currentProvider} failed:`,
+            error instanceof Error ? error.message : error
+          );
+          yield `Provider ${currentProvider} failed, trying next available provider...\n`;
+          currentProvider = getNextAvailableProvider('repo', currentProvider);
+        }
+      }
+
+      // If we get here, no providers worked
+      throw new ProviderError(noAvailableProvidersMsg);
+    } catch (error) {
+      if (error instanceof FileError || error instanceof ProviderError) {
+        yield error.formatUserMessage(options?.debug);
+      } else if (error instanceof Error) {
+        yield `Error: ${error.message}\n`;
+      } else {
+        yield 'An unknown error occurred\n';
+      }
+    }
+  }
+
+  private async getRepoSnapshot(
+    targetDirectory: string
+  ): Promise<{ content: string; tokenCount: number; warning?: string }> {
+    const repomixConfig = await loadFileConfigWithOverrides(targetDirectory, {
+      output: {
+        filePath: '.repomix-output.txt',
+      },
+    });
+
+    let packResult: AsyncReturnType<typeof pack> | undefined;
+    try {
+      packResult = await pack([targetDirectory], repomixConfig);
+      console.log(
+        `Packed repository. ${packResult.totalFiles} files. Approximate size ${packResult.totalTokens} tokens.`
+      );
+    } catch (error) {
+      throw new FileError('Failed to pack repository', error);
+    }
+
+    try {
+      // Check if Repomix created the output file as expected
+      if (!existsSync('.repomix-output.txt')) {
+        const warning =
+          'Warning: Repomix output file not found after pack operation. Repository context may be missing.';
+        writeFileSync('.repomix-output.txt', '');
+        return { content: '', tokenCount: 0, warning };
+      } else {
+        const content = readFileSync('.repomix-output.txt', 'utf-8');
+        return { content, tokenCount: packResult?.totalTokens || 0 };
+      }
+    } catch (error) {
+      throw new FileError('Failed to read repository context', error);
+    }
+  }
+
+  private async getGitDiff(baseBranch: string): Promise<{ diff: string; warning?: string }> {
+    try {
+      const { stdout } = await execAsync(`git diff ${baseBranch}...HEAD`);
+      if (!stdout || stdout.trim() === '') {
+        return { diff: '(No changes from ' + baseBranch + ')' };
+      }
+      return { diff: stdout };
+    } catch (error) {
+      const warning = `Warning: Could not compute diff from ${baseBranch}: ${error instanceof Error ? error.message : String(error)}`;
+      return {
+        diff: `(Diff unavailable - not a git repository or branch '${baseBranch}' not found)`,
+        warning,
+      };
+    }
+  }
+
+  private formatOutput(
+    repoSnapshot: { content: string },
+    diffContent: string,
+    query: string,
+    baseBranch: string
+  ): string {
+    return `<current-repository>
+${repoSnapshot.content}
+</current-repository>
+
+<changes base="${baseBranch}">
+${diffContent}
+</changes>
+
+<query>
+${query}
+</query>`;
+  }
+
+  private async *tryProvider(
+    provider: Provider,
+    formattedContent: string,
+    options: CommandOptions,
+    docContent: string
+  ): CommandGenerator {
+    console.log(`Trying provider: ${provider}`);
+    const modelProvider = createProvider(provider);
+    const modelName =
+      options?.model ||
+      this.config.repo?.model ||
+      (this.config as Record<string, any>)[provider]?.model ||
+      getDefaultModel(provider);
+
+    if (!modelName) {
+      throw new ProviderError(`No model specified for ${provider}`);
+    }
+
+    yield `Reviewing changes using ${modelName}...\n`;
+    try {
+      const maxTokens =
+        options?.maxTokens ||
+        this.config.repo?.maxTokens ||
+        (this.config as Record<string, any>)[provider]?.maxTokens ||
+        defaultMaxTokens;
+
+      const modelOptions: ModelOptions = {
+        model: modelName,
+        maxTokens,
+        debug: options.debug,
+        systemPrompt: `You are an expert code reviewer analyzing repository changes.
+          You will be provided with:
+          1. The current state of the repository (full context)
+          2. A git diff showing what changed from the base branch
+          3. A specific query or review request from the user
+          ${docContent ? '4. Additional context document from the user' : ''}
+          
+          Analyze the changes in the context of the full repository and provide a comprehensive review based on the user's query.
+          Focus on the changes shown in the diff, but use the full repository context to understand the impact.
+          
+          Be specific and reference exact file names and line numbers when discussing changes.`,
+      };
+
+      let fullPrompt = formattedContent;
+
+      if (docContent) {
+        fullPrompt += `\n\nCONTEXT DOCUMENT:\n${docContent}`;
+      }
+
+      const response = await modelProvider.executePrompt(fullPrompt, modelOptions);
+
+      // Track prompt/completion token usage
+      if ('tokenUsage' in modelProvider && modelProvider.tokenUsage) {
+        options?.trackTelemetry?.({
+          promptTokens: modelProvider.tokenUsage.promptTokens,
+          completionTokens: modelProvider.tokenUsage.completionTokens,
+          provider,
+          model: modelName,
+        });
+      } else {
+        options?.debug &&
+          console.log('[ReviewDiffCommand] tokenUsage not found on provider instance.');
+        options?.trackTelemetry?.({
+          provider,
+          model: modelName,
+        });
+      }
+
+      yield response;
+    } catch (error) {
+      throw new ProviderError(
+        error instanceof Error ? error.message : 'Unknown error during analysis',
+        error
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,9 @@ type CLIStringOption =
   | 'type'
   | 'format'
   // Test options
-  | 'scenarios';
+  | 'scenarios'
+  // Review-diff options
+  | 'base';
 
 type CLINumberOption =
   // Core options
@@ -136,6 +138,9 @@ interface CLIOptions {
   // Test options
   parallel?: number;
   scenarios?: string;
+
+  // Review-diff options
+  base?: string;
 }
 
 type CLIOptionKey = CLIStringOption | CLINumberOption | CLIBooleanOption;
@@ -191,6 +196,9 @@ const OPTION_KEYS: Record<string, CLIOptionKey> = {
   // Test options
   parallel: 'parallel',
   scenarios: 'scenarios',
+
+  // Review-diff options
+  base: 'base',
 };
 
 // Set of option keys that are boolean flags
@@ -327,6 +335,8 @@ async function main() {
     timeout: undefined,
     connectTo: undefined,
     parallel: undefined,
+    // Review-diff options
+    base: undefined,
     // Boolean options
     console: undefined,
     html: undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,9 @@ export interface CommandOptions {
 
   // Telemetry tracking
   trackTelemetry?: (data: Record<string, any>) => void; // Function to update telemetry data
+
+  // Review-diff options
+  base?: string; // Base branch for diff comparison
 }
 
 export interface Command {

--- a/src/vibe-rules.ts
+++ b/src/vibe-rules.ts
@@ -48,6 +48,9 @@ when using web for complex queries suggest writing the output to a file somewher
 \`vibe-tools repo "<your question>" [--subdir=<path>] [--from-github=<username/repo>] [--with-doc=<doc_url>...]\` - Get context-aware answers about this repository using Google Gemini (e.g., \`vibe-tools repo "explain authentication flow"\`)
 Use the optional \`--subdir\` parameter to analyze a specific subdirectory instead of the entire repository (e.g., \`vibe-tools repo "explain the code structure" --subdir=src/components\`). Use the optional \`--from-github\` parameter to analyze a remote GitHub repository without cloning it locally (e.g., \`vibe-tools repo "explain the authentication system" --from-github=username/repo-name\`). Use the optional \`--with-doc\` parameter multiple times to include content from several URLs as additional context (e.g., \`vibe-tools repo "summarize findings" --with-doc=https://example.com/spec1 --with-doc=https://example.com/spec2\`).
 
+**Code Review with Diff:**
+\`vibe-tools review-diff "<your review question>" [--base=<branch>] [--subdir=<path>] [--with-doc=<doc_url>]\` - Review code changes by providing both repository context and git diff against a base branch (e.g., \`vibe-tools review-diff "Review my authentication changes for security issues"\`). Use the optional \`--base\` parameter to specify a different base branch (default: main) (e.g., \`vibe-tools review-diff "What are the breaking changes?" --base=release-v2\`). Supports the same options as repo command for subdirectory analysis and document context.
+
 **Documentation Generation:**
 \`vibe-tools doc [options] [--with-doc=<doc_url>...]\` - Generate comprehensive documentation for this repository (e.g., \`vibe-tools doc --output docs.md\`). Can incorporate document context from multiple URLs (e.g., \`vibe-tools doc --with-doc=https://example.com/existing-docs --with-doc=https://example.com/new-spec\`).
 
@@ -98,6 +101,7 @@ The \`search\` command helps you discover servers in the MCP Marketplace and on 
 **Tool Recommendations:**
 - \`vibe-tools web\` is best for general web information not specific to the repository. Generally call this without additional arguments.
 - \`vibe-tools repo\` is ideal for repository-specific questions, planning, code review and debugging. E.g. \`vibe-tools repo "Review recent changes to command error handling looking for mistakes, omissions and improvements"\`. Generally call this without additional arguments.
+- \`vibe-tools review-diff\` is ideal for reviewing code changes with full context. Use when you need to review what has changed against a base branch. E.g. \`vibe-tools review-diff "Review my changes for potential bugs"\` or \`vibe-tools review-diff "Are there any breaking changes?" --base=develop\`.
 - \`vibe-tools plan\` is ideal for planning tasks. E.g. \`vibe-tools plan "Adding authentication with social login using Google and Github"\`. Generally call this without additional arguments.
 - \`vibe-tools doc\` generates documentation for local or remote repositories.
 - \`vibe-tools youtube\` analyzes YouTube videos to generate summaries, transcripts, implementation plans, or custom analyses


### PR DESCRIPTION
Getting review from Gemini is very helpful, but the way it is currently done with repomix does not send a changelog to LLM. I found adding diff along with the ouput of repomix to be very helpful - it keeps llm more focused on the current scope of changes.

## What this PR does

add command `review-diff` that gives the LLM both your git diff AND the full repo context from repomix.

So instead of just seeing what changed, the LLM understands how it fits into the whole codebase.

## Usage

```bash
# Basic review
vibe-tools review-diff "Review my changes"

# Against different branch
vibe-tools review-diff "Any breaking changes?" --base=develop

# With external docs
vibe-tools review-diff "Does this match the spec?" --with-doc=https://example.com/spec.md
```

## Implementation

- New command: `src/commands/review-diff.ts`
- Reuses existing repo/repomix infrastructure
- Adds `--base` flag for branch selection (default: main)
- Supports all standard options (provider, model, subdir, etc)
