### PR TITLE
Add --with-diff flag to repo command to send diff with the repo contents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,9 @@ type CLIStringOption =
   | 'type'
   | 'format'
   // Test options
-  | 'scenarios';
+  | 'scenarios'
+  // Git diff options
+  | 'base';
 
 type CLINumberOption =
   // Core options
@@ -83,7 +85,8 @@ type CLIBooleanOption =
   | 'network'
   | 'headless'
   | 'text'
-  | 'webSearch';
+  | 'webSearch'
+  | 'withDiff';
 
 // Main CLI options interface
 interface CLIOptions {
@@ -136,6 +139,10 @@ interface CLIOptions {
   // Test options
   parallel?: number;
   scenarios?: string;
+
+  // Git diff options
+  withDiff?: boolean;
+  base?: string;
 }
 
 type CLIOptionKey = CLIStringOption | CLINumberOption | CLIBooleanOption;
@@ -191,6 +198,10 @@ const OPTION_KEYS: Record<string, CLIOptionKey> = {
   // Test options
   parallel: 'parallel',
   scenarios: 'scenarios',
+
+  // Git diff options
+  withdiff: 'withDiff',
+  base: 'base',
 };
 
 // Set of option keys that are boolean flags
@@ -203,6 +214,7 @@ const BOOLEAN_OPTIONS = new Set<CLIBooleanOption>([
   'headless',
   'text',
   'webSearch',
+  'withDiff',
 ]);
 
 // Set of option keys that require numeric values
@@ -339,6 +351,9 @@ async function main() {
     reasoningEffort: undefined,
     subdir: undefined,
     withDoc: undefined,
+    // Git diff options
+    withDiff: undefined,
+    base: undefined,
   };
   const queryArgs: string[] = [];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,10 @@ export interface CommandOptions {
 
   // Telemetry tracking
   trackTelemetry?: (data: Record<string, any>) => void; // Function to update telemetry data
+
+  // Git diff options
+  withDiff?: boolean; // Include git diff in repository analysis
+  base?: string; // Base branch for diff comparison (default: main)
 }
 
 export interface Command {


### PR DESCRIPTION
This is a simpler implementation of my initial pr #155 

Add `--with-diff` flag to repo command for git diff integration

  Getting review from Gemini is very helpful, but the way it is currently done with repomix does not
  send a changelog to LLM. I found adding diff along with the output of repomix to be very helpful -
  it keeps the LLM more focused on the current scope of changes.

  ## What this PR does

  Adds --with-diff flag to the existing repo command that gives the LLM both your git diff AND the
  full repo context from repomix.

  So instead of just seeing what changed, the LLM understands how it fits into the whole codebase.


  Basic review
  vibe-tools repo "Review my changes" --with-diff

  Against different branch
  vibe-tools repo "Any breaking changes?" --with-diff --base=develop

   With external docs
  vibe-tools repo "Does this match the spec?" --with-diff --with-doc=https://example.com/spec.md

  Implementation

  - Extends existing repo command with --with-diff and --base flags
