### PR TITLE
feat: add global proxy support via HTTPS_PROXY using undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "playwright": "1.54.1",
     "playwright-core": "1.54.1",
     "punycode": "^2.3.1",
-    "repomix": "1.1.0"
+    "repomix": "1.1.0",
+    "undici": "^7.16.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       repomix:
         specifier: 1.1.0
         version: 1.1.0
+      undici:
+        specifier: ^7.16.0
+        version: 7.16.0
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.56.0
@@ -2169,6 +2172,10 @@ packages:
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+  undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -4462,6 +4469,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.8.0: {}
+
+  undici@7.16.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { setGlobalDispatcher, ProxyAgent } from 'undici';
 import { commands } from './commands/index.ts';
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -223,6 +224,21 @@ interface CLIOptions {
 }
 
 type CLIOptionKey = CLIStringOption | CLINumberOption | CLIBooleanOption;
+
+// Inject Proxy Support
+const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+if (proxyUrl) {
+  try {
+    const proxyAgent = new ProxyAgent(proxyUrl);
+    setGlobalDispatcher(proxyAgent);
+    // We check argv directly to avoid circular dependency with config/logging
+    if (process.argv.includes('--debug')) {
+      console.log(`[vibe-tools] Using Proxy: ${proxyUrl}`);
+    }
+  } catch (error) {
+    console.error(`[vibe-tools] Failed to configure proxy: ${(error as Error).message}`);
+  }
+}
 
 // Map of normalized keys to their option names in the options object
 const OPTION_KEYS: Record<string, CLIOptionKey> = {


### PR DESCRIPTION
**Problem:**
Currently, `vibe-tools` uses Node.js's native `fetch` API for network requests (e.g., in `src/providers/base.ts`). Unlike other CLI tools, native `fetch` does not automatically respect standard system proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`). This causes the calls of some models to fail with "User location not supported" or timeout errors for users working behind corporate firewalls or VPNs who rely on local proxies to bypass the location restrictions.

**Solution:**
I have integrated the `undici` library (the underlying http client for Node) to inject a global `ProxyAgent` when these environment variables are detected.

**Changes:**

1.  Added `undici` to dependencies.
2.  Modified `src/index.ts` to detect `process.env.HTTPS_PROXY` on startup.
3.  If detected, it registers a `setGlobalDispatcher` that routes all subsequent `fetch` requests through the defined proxy.

This implementation is **opt-in**: it only activates if the user has explicitly configured their environment variables, ensuring zero impact on standard users.